### PR TITLE
Fix #7. Make the Python Acquirer cooperatively call super, and test this.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 4.2.2 (unreleased)
 ------------------
 
-- TBD
+- Make the pure-Python Acquirer objects cooperatively use the
+  superclass ``__getattribute__`` method, like the C implementation.
+  See https://github.com/zopefoundation/Acquisition/issues/7.
 
 4.2.1 (2015-04-23)
 ------------------

--- a/src/Acquisition/tests.py
+++ b/src/Acquisition/tests.py
@@ -3124,6 +3124,30 @@ class TestAcquire(unittest.TestCase):
         found = self.acquire(self.a.b.c, AQ_PARENT)
         self.assertTrue(found.aq_self is self.a.b.aq_self)
 
+class TestCooperativeBase(unittest.TestCase):
+
+    def _make_acquirer(self, kind):
+        from ExtensionClass import Base
+
+        class ExtendsBase(Base):
+            def __getattribute__(self, name):
+                if name == 'magic':
+                    return 42
+                return super(ExtendsBase,self).__getattribute__(name)
+
+        class Acquirer(kind, ExtendsBase):
+            pass
+
+        return Acquirer()
+
+    def _check___getattribute___is_cooperative(self, acquirer):
+        self.assertEqual(getattr(acquirer, 'magic'), 42)
+
+    def test_implicit___getattribute__is_cooperative(self):
+        self._check___getattribute___is_cooperative(self._make_acquirer(Acquisition.Implicit))
+
+    def test_explicit___getattribute__is_cooperative(self):
+        self._check___getattribute___is_cooperative(self._make_acquirer(Acquisition.Explicit))
 
 class TestUnicode(unittest.TestCase):
 
@@ -3537,6 +3561,7 @@ def test_suite():
         unittest.makeSuite(TestAcquire),
         unittest.makeSuite(TestUnicode),
         unittest.makeSuite(TestProxying),
+        unittest.makeSuite(TestCooperativeBase),
     ]
 
     # This file is only available in a source checkout, skip it


### PR DESCRIPTION
Also provides a more informative traceback if lookup failed in that case, which assists debugging if the inheritance hierarchy is complex.