### PR TITLE
Make object.__getattribute__ work in methods wrapped with an acquisition wrapper.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,12 @@ Changelog
   superclass ``__getattribute__`` method, like the C implementation.
   See https://github.com/zopefoundation/Acquisition/issues/7.
 
+- The pure-Python implicit acquisition wrapper allows wrapped objects
+  to use ``object.__getattribute__(self, name)``. This differs from
+  the C implementation, but is important for compatibility with the
+  pure-Python versions of libraries like ``persistent``. See
+  https://github.com/zopefoundation/Acquisition/issues/9.
+
 4.2.1 (2015-04-23)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 4.2.2 (unreleased)
 ------------------
 
-- TBD
+- Make the pure-Python Acquirer objects cooperatively use the
+  superclass ``__getattribute__`` method, like the C implementation.
+  See https://github.com/zopefoundation/Acquisition/issues/7.
 
 4.2.1 (2015-04-23)
 ------------------

--- a/src/Acquisition/tests.py
+++ b/src/Acquisition/tests.py
@@ -3163,7 +3163,7 @@ if 'Acquisition._Acquisition' not in sys.modules:
         def test_object_getattribute_in_rebound_method_with_slots(self):
 
             class Persistent(object):
-                __slots__ = ('__flags')
+                __slots__ = ('__flags',)
                 def __init__(self):
                     self.__flags = 42
 
@@ -3187,7 +3187,7 @@ if 'Acquisition._Acquisition' not in sys.modules:
         def test_type_with_slots_reused(self):
 
             class Persistent(object):
-                __slots__ = ('__flags')
+                __slots__ = ('__flags',)
                 def __init__(self):
                     self.__flags = 42
 

--- a/src/Acquisition/tests.py
+++ b/src/Acquisition/tests.py
@@ -3124,6 +3124,30 @@ class TestAcquire(unittest.TestCase):
         found = self.acquire(self.a.b.c, AQ_PARENT)
         self.assertTrue(found.aq_self is self.a.b.aq_self)
 
+class TestCooperativeBase(unittest.TestCase):
+
+    def _make_acquirer(self, kind):
+        from ExtensionClass import Base
+
+        class ExtendsBase(Base):
+            def __getattribute__(self, name):
+                if name == 'magic':
+                    return 42
+                return super(ExtendsBase,self).__getattribute__(name)
+
+        class Acquirer(kind, ExtendsBase):
+            pass
+
+        return Acquirer()
+
+    def _check___getattribute___is_cooperative(self, acquirer):
+        self.assertEqual(getattr(acquirer, 'magic'), 42)
+
+    def test_implicit___getattribute__is_cooperative(self):
+        self._check___getattribute___is_cooperative(self._make_acquirer(Acquisition.Implicit))
+
+    def test_explicit___getattribute__is_cooperative(self):
+        self._check___getattribute___is_cooperative(self._make_acquirer(Acquisition.Explicit))
 
 class TestUnicode(unittest.TestCase):
 
@@ -3537,6 +3561,7 @@ def test_suite():
         unittest.makeSuite(TestAcquire),
         unittest.makeSuite(TestUnicode),
         unittest.makeSuite(TestProxying),
+        unittest.makeSuite(TestCooperativeBase),
     ]
 
     # This file is only available in a source checkout, skip it


### PR DESCRIPTION
Fixes #9. 

Builds on the commits for the previous issue, #7 slash #8 because both of them are required to do any serious Persistent work in pure-Python when Acquisition is involved and this is now the branch we're continuing to test our application against.