### PR TITLE
Fix wrapping of matmul and imatmul

### DIFF
--- a/src/Acquisition/__init__.py
+++ b/src/Acquisition/__init__.py
@@ -567,6 +567,7 @@ class _Wrapper(ExtensionClass.Base):
         '__add__',
         '__sub__',
         '__mul__',
+        '__matmul__',
         '__floordiv__',  # not implemented in C
         '__mod__',
         '__divmod__',
@@ -601,6 +602,7 @@ class _Wrapper(ExtensionClass.Base):
         '__iadd__',
         '__isub__',
         '__imul__',
+        '__imatmul__',
         '__idiv__',
         '__itruediv__',
         '__ifloordiv__',

--- a/src/Acquisition/tests.py
+++ b/src/Acquisition/tests.py
@@ -3358,6 +3358,12 @@ class TestProxying(unittest.TestCase):
         # '__coerce__',
     ]
 
+    if PY3 and sys.version_info.minor >= 5:
+        __binary_numeric_methods__.extend([
+            '__matmul__',
+            '__imatmul__'
+        ])
+
     __unary_special_methods__ = [
         # arithmetic
         '__neg__',

--- a/src/Acquisition/tests.py
+++ b/src/Acquisition/tests.py
@@ -3382,7 +3382,7 @@ class TestProxying(unittest.TestCase):
         # Check that special methods are proxied
         # when called implicitly by the interpreter
 
-        def binary_acquired_func(self, other):
+        def binary_acquired_func(self, other, modulo=None):
             return self.value
 
         def unary_acquired_func(self):
@@ -3426,9 +3426,11 @@ class TestProxying(unittest.TestCase):
         _found_at_least_one_div = False
 
         for meth in self.__binary_numeric_methods__:
-            # called on the instance
-            self.assertEqual(base.value,
-                             getattr(base.derived, meth)(-1))
+            op = getattr(operator, meth, None)
+            if op is not None:
+                # called on the instance
+                self.assertEqual(base.value, op(base.derived, -1))
+
             # called on the type, as the interpreter does
             # Note that the C version can only implement either __truediv__
             # or __div__, not both


### PR DESCRIPTION
The slots for matrix multiplication `__matmul__` and `__imatmul__` were not properly wrapped by the python version.

Important. This branch is based on https://github.com/zopefoundation/Acquisition/tree/c-extension-py3
not on master. The unittests rely on the C-version to wrap the other new number operators (like `__iadd__`) properly.