### PR TITLE
C extension clean

### DIFF
--- a/include/ExtensionClass/ExtensionClass.h
+++ b/include/ExtensionClass/ExtensionClass.h
@@ -19,61 +19,61 @@
   Extension Class Definitions
 
   Implementing base extension classes
-  
+
     A base extension class is implemented in much the same way that an
     extension type is implemented, except:
-  
+
     - The include file, 'ExtensionClass.h', must be included.
- 
+
     - The type structure is declared to be of type
-	  'PyExtensionClass', rather than of type 'PyTypeObject'.
- 
+      'PyExtensionClass', rather than of type 'PyTypeObject'.
+
     - The type structure has an additional member that must be defined
-	  after the documentation string.  This extra member is a method chain
-	  ('PyMethodChain') containing a linked list of method definition
-	  ('PyMethodDef') lists.  Method chains can be used to implement
-	  method inheritance in C.  Most extensions don't use method chains,
-	  but simply define method lists, which are null-terminated arrays
-	  of method definitions.  A macro, 'METHOD_CHAIN' is defined in
-	  'ExtensionClass.h' that converts a method list to a method chain.
-	  (See the example below.)
-  
+      after the documentation string.  This extra member is a method chain
+      ('PyMethodChain') containing a linked list of method definition
+      ('PyMethodDef') lists.  Method chains can be used to implement
+      method inheritance in C.  Most extensions don't use method chains,
+      but simply define method lists, which are null-terminated arrays
+      of method definitions.  A macro, 'METHOD_CHAIN' is defined in
+      'ExtensionClass.h' that converts a method list to a method chain.
+      (See the example below.)
+
     - Module functions that create new instances must be replaced by an
-	  '__init__' method that initializes, but does not create storage for 
-	  instances.
-  
+      '__init__' method that initializes, but does not create storage for
+      instances.
+
     - The extension class must be initialized and exported to the module
-	  with::
-  
-	      PyExtensionClass_Export(d,"name",type);
-  
-	  where 'name' is the module name and 'type' is the extension class
-	  type object.
-  
+      with::
+
+          PyExtensionClass_Export(d,"name",type);
+
+      where 'name' is the module name and 'type' is the extension class
+      type object.
+
     Attribute lookup
-  
-	  Attribute lookup is performed by calling the base extension class
-	  'getattr' operation for the base extension class that includes C
-	  data, or for the first base extension class, if none of the base
-	  extension classes include C data.  'ExtensionClass.h' defines a
-	  macro 'Py_FindAttrString' that can be used to find an object's
-	  attributes that are stored in the object's instance dictionary or
-	  in the object's class or base classes::
-  
-	     v = Py_FindAttrString(self,name);
-  
-	  In addition, a macro is provided that replaces 'Py_FindMethod'
-	  calls with logic to perform the same sort of lookup that is
-	  provided by 'Py_FindAttrString'.
-  
+
+      Attribute lookup is performed by calling the base extension class
+      'getattr' operation for the base extension class that includes C
+      data, or for the first base extension class, if none of the base
+      extension classes include C data.  'ExtensionClass.h' defines a
+      macro 'Py_FindAttrString' that can be used to find an object's
+      attributes that are stored in the object's instance dictionary or
+      in the object's class or base classes::
+
+         v = Py_FindAttrString(self,name);
+
+    In addition, a macro is provided that replaces 'Py_FindMethod'
+    calls with logic to perform the same sort of lookup that is
+    provided by 'Py_FindAttrString'.
+
     Linking
-  
-	  The extension class mechanism was designed to be useful with
-	  dynamically linked extension modules.  Modules that implement
-	  extension classes do not have to be linked against an extension
-	  class library.  The macro 'PyExtensionClass_Export' imports the
-	  'ExtensionClass' module and uses objects imported from this module
-	  to initialize an extension class with necessary behavior.
+
+      The extension class mechanism was designed to be useful with
+      dynamically linked extension modules.  Modules that implement
+      extension classes do not have to be linked against an extension
+      class library.  The macro 'PyExtensionClass_Export' imports the
+      'ExtensionClass' module and uses objects imported from this module
+      to initialize an extension class with necessary behavior.
 
 */
 
@@ -106,7 +106,7 @@ static struct ExtensionClassCAPIstruct {
 
 
   PyObject *(*EC_findiattrs_)(PyObject *self, char *cname);
-  int (*PyExtensionClass_Export_)(PyObject *dict, char *name, 
+  int (*PyExtensionClass_Export_)(PyObject *dict, char *name,
                                   PyTypeObject *typ);
   PyObject *(*PyECMethod_New_)(PyObject *callable, PyObject *inst);
   PyExtensionClass *ECBaseType_;
@@ -128,7 +128,7 @@ static struct ExtensionClassCAPIstruct {
    lookup methods or attributes that are not managed by the base type
    directly.  The macro is generally used to search for attributes
    after other attribute searches have failed.
-   
+
    Note that in Python 1.4, a getattr operation may be provided that
    uses an object argument. Classes that support this new operation
    should use Py_FindAttr.
@@ -145,7 +145,7 @@ static struct ExtensionClassCAPIstruct {
    lookup methods or attributes that are not managed by the base type
    directly.  The macro is generally used to search for attributes
    after other attribute searches have failed.
-   
+
    Note that in Python 1.4, a getattr operation may be provided that
    uses an object argument. Classes that support this new operation
    should use Py_FindAttr.
@@ -179,9 +179,9 @@ static struct ExtensionClassCAPIstruct {
 
 /* The following macro checks whether an instance is an extension instance: */
 #define PyExtensionInstance_Check(INST) \
-  PyObject_TypeCheck(((PyObject*)(INST))->ob_type, ECExtensionClassType)
+  PyObject_TypeCheck(Py_TYPE(INST), ECExtensionClassType)
 
-#define CHECK_FOR_ERRORS(MESS) 
+#define CHECK_FOR_ERRORS(MESS)
 
 /* The following macro can be used to define an extension base class
    that only provides method and that is used as a pure mix-in class. */
@@ -208,19 +208,17 @@ static PyExtensionClass NAME ## Type = { PyVarObject_HEAD_INIT(NULL, 0) # NAME, 
   PyExtensionClassCAPI->PyECMethod_New_((CALLABLE),(INST))
 
 /* Return the instance that is bound by an extension class method. */
-#define PyECMethod_Self(M) \
-(PyMethod_Check((M)) ? ((PyMethodObject*)(M))->im_self : NULL)
+#define PyECMethod_Self(M) (PyMethod_Check((M)) ? PyMethod_GET_SELF(M) : NULL)
 
 /* Check whether an object has an __of__ method for returning itself
    in the context of it's container. */
-#define has__of__(O) (PyObject_TypeCheck((O)->ob_type, ECExtensionClassType) \
-                      && (O)->ob_type->tp_descr_get != NULL)
+#define has__of__(O) (PyExtensionInstance_Check(O) && Py_TYPE(O)->tp_descr_get != NULL)
 
 /* The following macros are used to check whether an instance
    or a class' instanses have instance dictionaries: */
 #define HasInstDict(O) (_PyObject_GetDictPtr(O) != NULL)
 
-#define ClassHasInstDict(C) ((C)->tp_dictoffset > 0))
+#define ClassHasInstDict(C) ((C)->tp_dictoffset > 0)
 
 /* Get an object's instance dictionary.  Use with caution */
 #define INSTANCE_DICT(inst) (_PyObject_GetDictPtr(O))
@@ -228,7 +226,7 @@ static PyExtensionClass NAME ## Type = { PyVarObject_HEAD_INIT(NULL, 0) # NAME, 
 /* Test whether an ExtensionClass, S, is a subclass of ExtensionClass C. */
 #define ExtensionClassSubclass_Check(S,C) PyType_IsSubtype((S), (C))
 
-/* Test whether an ExtensionClass instance , I, is a subclass of 
+/* Test whether an ExtensionClass instance , I, is a subclass of
    ExtensionClass C. */
 #define ExtensionClassSubclassInstance_Check(I,C) PyObject_TypeCheck((I), (C))
 
@@ -245,23 +243,5 @@ static PyExtensionClass NAME ## Type = { PyVarObject_HEAD_INIT(NULL, 0) # NAME, 
 #define ExtensionClassImported \
   ((PyExtensionClassCAPI != NULL) || \
    (PyExtensionClassCAPI = PyCapsule_Import("ExtensionClass.CAPI2", 0)))
-
-
-/* These are being overridded to use tp_free when used with
-   new-style classes. This is to allow old extention-class code
-   to work.
-*/
-
-#undef PyMem_DEL
-#undef PyObject_DEL
-
-#define PyMem_DEL(O)                                   \
-  if (((O)->ob_type->tp_flags & Py_TPFLAGS_HAVE_CLASS) \
-      && ((O)->ob_type->tp_free != NULL))              \
-    (O)->ob_type->tp_free((PyObject*)(O));             \
-  else                                                 \
-    PyObject_FREE((O));
-
-#define PyObject_DEL(O) PyMem_DEL(O)
 
 #endif /* EXTENSIONCLASS_H */

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -1594,6 +1594,7 @@ acquire_of(PyObject *self, PyObject *inst, PyExtensionClass *target)
     return newWrapper(self, inst, target);
 
 }
+
 static PyObject *
 aq__of__(PyObject *self, PyObject *inst)
 {
@@ -1752,37 +1753,21 @@ module_aq_get(PyObject *r, PyObject *args)
 
 static int 
 capi_aq_iswrapper(PyObject *self) {
-	return isWrapper(self);
+    return isWrapper(self);
 }
 
 static PyObject *
 capi_aq_base(PyObject *self)
 {
-  PyObject *result;
-  if (! isWrapper(self)) 
-    {
-      Py_INCREF(self);
-      return self;
-    }
-  
-  if (WRAPPER(self)->obj)
-    {
-      result=WRAPPER(self)->obj;
-      while (isWrapper(result) && WRAPPER(result)->obj)
-      	result=WRAPPER(result)->obj;
-    }
-  else result=Py_None;
-  Py_INCREF(result);
-  return result;
+    PyObject *result = get_base(self);
+    Py_INCREF(result);
+    return result;
 }
 
 static PyObject *
-module_aq_base(PyObject *ignored, PyObject *args)
+module_aq_base(PyObject *ignored, PyObject *self)
 {
-  PyObject *self;
-  UNLESS (PyArg_ParseTuple(args, "O", &self)) return NULL;
-
-  return capi_aq_base(self);
+    return capi_aq_base(self);
 }
 
 static PyObject *
@@ -2015,7 +2000,7 @@ static struct PyMethodDef methods[] = {
    "aq_get(ob, name [, default]) -- "
    "Get an attribute, acquiring it if necessary."
   },
-  {"aq_base", (PyCFunction)module_aq_base, METH_VARARGS, 
+  {"aq_base", (PyCFunction)module_aq_base, METH_O,
    "aq_base(ob) -- Get the object unwrapped"},
   {"aq_parent", (PyCFunction)module_aq_parent, METH_VARARGS, 
    "aq_parent(ob) -- Get the parent of an object"},

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -1826,36 +1826,20 @@ module_aq_self(PyObject *ignored, PyObject *self)
 static PyObject *
 capi_aq_inner(PyObject *self)
 {
-  PyObject *result;
-  if (! isWrapper(self)) 
-    {
-      Py_INCREF(self);
-      return self;
+    if (isWrapper(self)) {
+        while (isWrapper(WRAPPER(self)->obj)) {
+            self = WRAPPER(self)->obj;
+        }
     }
 
-  if (WRAPPER(self)->obj)
-    {
-      result=WRAPPER(self)->obj;
-      while (isWrapper(result) && WRAPPER(result)->obj) 
-	{
-	  self=result;
-	  result=WRAPPER(result)->obj;
-	}
-      result=self;
-    }
-  else result=Py_None;
-
-  Py_INCREF(result);
-  return result;
+    Py_INCREF(self);
+    return self;
 }
 
 static PyObject *
-module_aq_inner(PyObject *ignored, PyObject *args)
+module_aq_inner(PyObject *ignored, PyObject *self)
 {
-  PyObject *self;
-
-  UNLESS (PyArg_ParseTuple(args, "O", &self)) return NULL;
-  return capi_aq_inner(self);
+    return capi_aq_inner(self);
 }
 
 static PyObject *
@@ -1991,7 +1975,7 @@ static struct PyMethodDef methods[] = {
    "aq_parent(ob) -- Get the parent of an object"},
   {"aq_self", (PyCFunction)module_aq_self, METH_O,
    "aq_self(ob) -- Get the object with the outermost wrapper removed"},
-  {"aq_inner", (PyCFunction)module_aq_inner, METH_VARARGS, 
+  {"aq_inner", (PyCFunction)module_aq_inner, METH_O,
    "aq_inner(ob) -- "
    "Get the object with all but the innermost wrapper removed"},
   {"aq_chain", (PyCFunction)module_aq_chain, METH_VARARGS, 

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -422,39 +422,34 @@ static int
 apply_filter(PyObject *filter, PyObject *inst, PyObject *oname, PyObject *r,
 	     PyObject *extra, PyObject *orig)
 {
-  /* Calls the filter, passing arguments.
+    /* Calls the filter, passing arguments.
 
-  Returns 1 if the filter accepts the value, 0 if not, -1 if an
-  exception occurred.
+    Returns 1 if the filter accepts the value, 0 if not, -1 if an
+    exception occurred.
 
-  Note the special reference counting rule: This function decrements
-  the refcount of 'r' when it returns 0 or -1.  When it returns 1, it
-  leaves the refcount unchanged.
-  */
+    Note the special reference counting rule: This function decrements
+    the refcount of 'r' when it returns 0 or -1.  When it returns 1, it
+    leaves the refcount unchanged.
+    */
 
-  PyObject *fr;
-  int ir;
+    PyObject *py_res;
+    int res;
 
-  UNLESS(fr=PyTuple_New(5)) goto err;
-  PyTuple_SET_ITEM(fr,0,orig);
-  Py_INCREF(orig);
-  PyTuple_SET_ITEM(fr,1,inst);
-  Py_INCREF(inst);
-  PyTuple_SET_ITEM(fr,2,oname);
-  Py_INCREF(oname);
-  PyTuple_SET_ITEM(fr,3,r);
-  Py_INCREF(r);
-  PyTuple_SET_ITEM(fr,4,extra);
-  Py_INCREF(extra);
-  UNLESS_ASSIGN(fr,PyObject_CallObject(filter, fr)) goto err;
-  ir=PyObject_IsTrue(fr);
-  Py_DECREF(fr);
-  if (ir) return 1;
-  Py_DECREF(r);
-  return 0;
-err:
-  Py_DECREF(r);
-  return -1;
+    py_res = PyObject_CallFunctionObjArgs(filter, orig, inst, oname, r, extra, NULL);
+    if (py_res == NULL) {
+        Py_DECREF(r);
+        return -1;
+    }
+
+    res = PyObject_IsTrue(py_res);
+    Py_DECREF(py_res);
+
+    if (res == 0 || res == -1) {
+        Py_DECREF(r);
+        return res;
+    }
+
+    return 1;
 }
 
 static PyObject *

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -822,11 +822,7 @@ Wrapper_acquire(
 static PyObject *
 Wrapper_getattro(Wrapper *self, PyObject *oname)
 {
-  if (self->obj || self->container)
     return Wrapper_findattr(self, oname, NULL, NULL, NULL, 1, 1, 0, 0);
-
-  /* Maybe we are getting initialized? */
-  return Py_FindAttr(OBJECT(self),oname);
 }
 
 static PyObject *

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -51,7 +51,10 @@ static PyObject *py__add__, *py__sub__, *py__mul__, *py__div__,
   *py__getitem__, *py__setitem__, *py__delitem__,
   *py__getslice__, *py__setslice__, *py__delslice__,  *py__contains__,
   *py__len__, *py__of__, *py__call__, *py__repr__, *py__str__, *py__unicode__,
-  *py__cmp__, *py__parent__, *py__iter__, *py__bool__;
+  *py__cmp__, *py__parent__, *py__iter__, *py__bool__, *py__index__, *py__iadd__,
+  *py__isub__, *py__imul__, *py__imod__, *py__ipow__, *py__ilshift__, *py__irshift__,
+  *py__iand__, *py__ixor__, *py__ior__, *py__floordiv__, *py__truediv__,
+  *py__ifloordiv__, *py__itruediv__, *py__matmul__, *py__imatmul__, *py__idiv__;
 
 static PyObject *Acquired=0;
 
@@ -99,6 +102,24 @@ init_py_names(void)
   INIT_PY_NAME(__cmp__);
   INIT_PY_NAME(__parent__);
   INIT_PY_NAME(__iter__);
+  INIT_PY_NAME(__index__);
+  INIT_PY_NAME(__iadd__);
+  INIT_PY_NAME(__isub__);
+  INIT_PY_NAME(__imul__);
+  INIT_PY_NAME(__imod__);
+  INIT_PY_NAME(__ipow__);
+  INIT_PY_NAME(__ilshift__);
+  INIT_PY_NAME(__irshift__);
+  INIT_PY_NAME(__iand__);
+  INIT_PY_NAME(__ixor__);
+  INIT_PY_NAME(__ior__);
+  INIT_PY_NAME(__floordiv__);
+  INIT_PY_NAME(__truediv__);
+  INIT_PY_NAME(__ifloordiv__);
+  INIT_PY_NAME(__itruediv__);
+  INIT_PY_NAME(__matmul__);
+  INIT_PY_NAME(__imatmul__);
+  INIT_PY_NAME(__idiv__);
 #undef INIT_PY_NAME
 }
 
@@ -1153,17 +1174,17 @@ static PyMappingMethods Wrapper_as_mapping = {
 
 #define WRAP_UNARYOP(OPNAME) \
     static PyObject* Wrapper_##OPNAME(PyObject* self) { \
-        return PyObject_CallMethod(self, "__"#OPNAME"__", NULL); \
+        return PyObject_CallMethodObjArgs(self, py__##OPNAME##__, NULL); \
     }
 
 #define WRAP_BINOP(OPNAME) \
     static PyObject* Wrapper_##OPNAME(PyObject* self, PyObject* o1) { \
-        return PyObject_CallMethod(self, "__"#OPNAME"__", "O", o1); \
+        return CallMethodArgs(self, py__##OPNAME##__, "(O)", o1); \
     }
 
 #define WRAP_TERNARYOP(OPNAME) \
     static PyObject* Wrapper_##OPNAME(PyObject* self, PyObject* o1, PyObject* o2) { \
-        return PyObject_CallMethod(self, "__"#OPNAME"__", "OO", o1, o2); \
+        return CallMethodArgs(self, py__##OPNAME##__, "(OO)", o1, o2); \
     }
 
 WRAP_BINOP(sub);

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -285,35 +285,16 @@ Wrapper_descrget(Wrapper *self, PyObject *inst, PyObject *cls)
 static int
 Wrapper_traverse(Wrapper *self, visitproc visit, void *arg)
 {
-    int vret;
-
-    if (self->obj) {
-        vret = visit(self->obj, arg);
-        if (vret != 0)
-            return vret;
-    }
-    if (self->container) {
-        vret = visit(self->container, arg);
-        if (vret != 0)
-            return vret;
-    }
-
+    Py_VISIT(self->obj);
+    Py_VISIT(self->container);
     return 0;
 }
 
 static int 
 Wrapper_clear(Wrapper *self)
 {
-    PyObject *tmp;
-
-    tmp = self->obj;
-    self->obj = NULL;
-    Py_XDECREF(tmp);
-
-    tmp = self->container;
-    self->container = NULL;
-    Py_XDECREF(tmp);
-
+    Py_CLEAR(self->obj);
+    Py_CLEAR(self->container);
     return 0;
 }
 

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -938,58 +938,49 @@ Wrapper_richcompare(Wrapper *self, PyObject *w, int op)
 static PyObject *
 Wrapper_repr(Wrapper *self)
 {
-  PyObject *r;
+    PyObject *r;
 
-  if ((r=PyObject_GetAttr(OBJECT(self),py__repr__)))
-    {
-      ASSIGN(r,PyObject_CallFunction(r,NULL,NULL));
-      return r;
-    }
-  else
-    {
-      PyErr_Clear();
-      return PyObject_Repr(self->obj);
+    if ((r = PyObject_GetAttr(OBJECT(self), py__repr__))) {
+        ASSIGN(r, PyObject_CallFunction(r, NULL, NULL));
+        return r;
+    } else {
+        PyErr_Clear();
+        return PyObject_Repr(self->obj);
     }
 }
 
 static PyObject *
 Wrapper_str(Wrapper *self)
 {
-  PyObject *r;
+    PyObject *r;
 
-  if ((r=PyObject_GetAttr(OBJECT(self),py__str__)))
-    {
-      ASSIGN(r,PyObject_CallFunction(r,NULL,NULL));
-      return r;
-    }
-  else
-    {
-      PyErr_Clear();
-      return PyObject_Str(self->obj);
+    if ((r = PyObject_GetAttr(OBJECT(self), py__str__))) {
+        ASSIGN(r, PyObject_CallFunction(r,NULL,NULL));
+        return r;
+    } else {
+        PyErr_Clear();
+        return PyObject_Str(self->obj);
     }
 }
 
 static PyObject *
 Wrapper_unicode(Wrapper *self)
 {
-  PyObject *r;
+    PyObject *r;
 
-  if ((r=PyObject_GetAttr(OBJECT(self),py__unicode__)))
-    {
-      ASSIGN(r,PyObject_CallFunction(r,NULL,NULL));
-      return r;
-    }
-  else
-    {
-      PyErr_Clear();
-      return Wrapper_str(self);
+    if ((r = PyObject_GetAttr(OBJECT(self), py__unicode__))) {
+        ASSIGN(r, PyObject_CallFunction(r, NULL, NULL));
+        return r;
+    } else {
+        PyErr_Clear();
+        return Wrapper_str(self);
     }
 }
 
 static long
 Wrapper_hash(Wrapper *self)
 {
-  return PyObject_Hash(self->obj);
+    return PyObject_Hash(self->obj);
 }
 
 static PyObject *

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -643,10 +643,8 @@ Wrapper_findattr_name(Wrapper *self, char* name, PyObject *oname,
                 if (PyECMethod_Check(r) && PyECMethod_Self(r) == self->obj) {
                     ASSIGN(r, PyECMethod_New(r, OBJECT(self)));
                 }
-                else if (has__of__(r)) {
-                  ASSIGN(r, __of__(r, OBJECT(self)));
-                }
-                return r;
+                return apply__of__(r, OBJECT(self));
+
             } else if (!swallow_attribute_error()) {
                 return NULL;
             }
@@ -673,9 +671,9 @@ Wrapper_findattr_name(Wrapper *self, char* name, PyObject *oname,
 
             if (PyECMethod_Check(r) && PyECMethod_Self(r) == self->obj) {
                 ASSIGN(r, PyECMethod_New(r, OBJECT(self)));
-            } else if (has__of__(r)) {
-                ASSIGN(r, __of__(r, OBJECT(self)));
             }
+
+            r = apply__of__(r, OBJECT(self));
 
             if (r && filter) {
                 switch(apply_filter(filter, OBJECT(self), oname, r, extra, orig)) {

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -2014,62 +2014,63 @@ static struct PyModuleDef moduledef =
 static PyObject*
 module_init(void)
 {
-  PyObject *m, *d;
-  PyObject *api;
+    PyObject *m, *d;
+    PyObject *api;
 
-  PURE_MIXIN_CLASS(Acquirer,
-    "Base class for objects that implicitly"
-    " acquire attributes from containers\n",
-    Acquirer_methods);
+    PURE_MIXIN_CLASS(Acquirer,
+                     "Base class for objects that implicitly"
+                     " acquire attributes from containers\n",
+                     Acquirer_methods);
 
-  PURE_MIXIN_CLASS(ExplicitAcquirer,
-    "Base class for objects that explicitly"
-    " acquire attributes from containers\n",
-    ExplicitAcquirer_methods);
+    PURE_MIXIN_CLASS(ExplicitAcquirer,
+                     "Base class for objects that explicitly"
+                     " acquire attributes from containers\n",
+                     ExplicitAcquirer_methods);
 
-  UNLESS(ExtensionClassImported) return NULL;
+    if (!ExtensionClassImported) {
+        return NULL;
+    }
 
-  Acquired = NATIVE_FROM_STRING("<Special Object Used to Force Acquisition>");
-  if (Acquired == NULL) {
-      return NULL;
-  }
+    Acquired = NATIVE_FROM_STRING("<Special Object Used to Force Acquisition>");
+    if (Acquired == NULL) {
+        return NULL;
+    }
 
 #ifdef PY3K
-  m = PyModule_Create(&moduledef);
+    m = PyModule_Create(&moduledef);
 #else
-  m = Py_InitModule3(
-        "_Acquisition",
-        methods,
-	    "Provide base classes for acquiring objects\n\n");
+    m = Py_InitModule3("_Acquisition",
+                       methods,
+                       "Provide base classes for acquiring objects\n\n");
 #endif
 
-  d = PyModule_GetDict(m);
-  init_py_names();
-  PyExtensionClass_Export(d,"Acquirer",AcquirerType);
-  PyExtensionClass_Export(d,"ImplicitAcquisitionWrapper",Wrappertype);
-  PyExtensionClass_Export(d,"ExplicitAcquirer",ExplicitAcquirerType);
-  PyExtensionClass_Export(d,"ExplicitAcquisitionWrapper",XaqWrappertype);
+    d = PyModule_GetDict(m);
+    init_py_names();
+    PyExtensionClass_Export(d,"Acquirer", AcquirerType);
+    PyExtensionClass_Export(d,"ImplicitAcquisitionWrapper", Wrappertype);
+    PyExtensionClass_Export(d,"ExplicitAcquirer", ExplicitAcquirerType);
+    PyExtensionClass_Export(d,"ExplicitAcquisitionWrapper", XaqWrappertype);
 
-  /* Create aliases */
-  PyDict_SetItemString(d,"Implicit",OBJECT(&AcquirerType));
-  PyDict_SetItemString(d,"Explicit",OBJECT(&ExplicitAcquirerType));
-  PyDict_SetItemString(d,"Acquired",Acquired);
+    /* Create aliases */
+    PyDict_SetItemString(d,"Implicit", OBJECT(&AcquirerType));
+    PyDict_SetItemString(d,"Explicit", OBJECT(&ExplicitAcquirerType));
+    PyDict_SetItemString(d,"Acquired", Acquired);
 
-  AcquisitionCAPI.AQ_Acquire = capi_aq_acquire;
-  AcquisitionCAPI.AQ_Get = capi_aq_get;
-  AcquisitionCAPI.AQ_IsWrapper = capi_aq_iswrapper;
-  AcquisitionCAPI.AQ_Base = capi_aq_base;
-  AcquisitionCAPI.AQ_Parent = capi_aq_parent;
-  AcquisitionCAPI.AQ_Self = capi_aq_self;
-  AcquisitionCAPI.AQ_Inner = capi_aq_inner;
-  AcquisitionCAPI.AQ_Chain = capi_aq_chain;
+    AcquisitionCAPI.AQ_Acquire = capi_aq_acquire;
+    AcquisitionCAPI.AQ_Get = capi_aq_get;
+    AcquisitionCAPI.AQ_IsWrapper = capi_aq_iswrapper;
+    AcquisitionCAPI.AQ_Base = capi_aq_base;
+    AcquisitionCAPI.AQ_Parent = capi_aq_parent;
+    AcquisitionCAPI.AQ_Self = capi_aq_self;
+    AcquisitionCAPI.AQ_Inner = capi_aq_inner;
+    AcquisitionCAPI.AQ_Chain = capi_aq_chain;
 
-  api = PyCapsule_New(&AcquisitionCAPI, "AcquisitionCAPI", NULL);
+    api = PyCapsule_New(&AcquisitionCAPI, "AcquisitionCAPI", NULL);
 
-  PyDict_SetItemString(d, "AcquisitionCAPI", api);
-  Py_DECREF(api);
+    PyDict_SetItemString(d, "AcquisitionCAPI", api);
+    Py_DECREF(api);
 
-  return m;
+    return m;
 }
 
 #ifdef PY3K

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -192,32 +192,34 @@ static PyExtensionClass Wrappertype, XaqWrappertype;
 static int
 Wrapper__init__(Wrapper *self, PyObject *args, PyObject *kwargs)
 {
-  PyObject *obj, *container;
+    PyObject *obj, *container;
 
-  if (kwargs && PyDict_Size(kwargs) != 0)
-    {
-      PyErr_SetString(PyExc_TypeError,
-                      "kwyword arguments not allowed");
-      return -1;
+    if (kwargs && PyDict_Size(kwargs) != 0) {
+        PyErr_SetString(PyExc_TypeError,
+                        "kwyword arguments not allowed");
+        return -1;
     }
 
-  UNLESS(PyArg_ParseTuple(args, "OO:__init__", &obj, &container)) return -1;
-
-  if (self == WRAPPER(obj)) {
-  	PyErr_SetString(PyExc_ValueError,
-		"Cannot wrap acquisition wrapper in itself (Wrapper__init__)");
-  	return -1;
-  }
-
-  Py_INCREF(obj);
-  self->obj=obj;
-
-  if (container != Py_None)
-    {
-      Py_INCREF(container);
-      self->container=container;
+    if (!PyArg_ParseTuple(args, "OO:__init__", &obj, &container)) {
+        return -1;
     }
-  return 0;
+
+    if (self == WRAPPER(obj)) {
+        PyErr_SetString(PyExc_ValueError,
+                        "Cannot wrap acquisition wrapper "
+                        "in itself (Wrapper__init__)");
+        return -1;
+    }
+
+    Py_INCREF(obj);
+    self->obj = obj;
+
+    if (container != Py_None) {
+        Py_INCREF(container);
+        self->container=container;
+    }
+
+    return 0;
 }
 
 /* ---------------------------------------------------------------- */
@@ -270,17 +272,13 @@ __of__(PyObject *inst, PyObject *parent)
 static PyObject *
 Wrapper_descrget(Wrapper *self, PyObject *inst, PyObject *cls)
 {
-
-  if (inst == NULL)
-    {
-      Py_INCREF(self);
-      return (PyObject *)self;
+    if (inst == NULL) {
+        Py_INCREF(self);
+        return OBJECT(self);
     }
-  
-  return __of__((PyObject *)self, inst);
+
+    return __of__(OBJECT(self), inst);
 }
-
-
 
 static int
 Wrapper_traverse(Wrapper *self, visitproc visit, void *arg)
@@ -301,8 +299,8 @@ Wrapper_clear(Wrapper *self)
 static void
 Wrapper_dealloc(Wrapper *self)     
 {
-  Wrapper_clear(self);
-  Py_TYPE(self)->tp_free((PyObject*)self);
+    Wrapper_clear(self);
+    Py_TYPE(self)->tp_free(OBJECT(self));
 }
 
 static PyObject *

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -1805,26 +1805,22 @@ module_aq_parent(PyObject *ignored, PyObject *self)
 static PyObject *
 capi_aq_self(PyObject *self)
 {
-  PyObject *result;
-  if (! isWrapper(self)) 
-    {
-      Py_INCREF(self);
-      return self;
-    }
-  
-  if (WRAPPER(self)->obj) result=WRAPPER(self)->obj;
-  else result=Py_None;
+    PyObject *result;
 
-  Py_INCREF(result);
-  return result;
+    if (!isWrapper(self)) {
+        result = self;
+    } else {
+        result = WRAPPER(self)->obj;
+    }
+
+    Py_INCREF(result);
+    return result;
 }
 
 static PyObject *
-module_aq_self(PyObject *ignored, PyObject *args)
+module_aq_self(PyObject *ignored, PyObject *self)
 {
-  PyObject *self;
-  UNLESS (PyArg_ParseTuple(args, "O", &self)) return NULL;
-  return capi_aq_self(self);
+    return capi_aq_self(self);
 }
 
 static PyObject *
@@ -1993,7 +1989,7 @@ static struct PyMethodDef methods[] = {
    "aq_base(ob) -- Get the object unwrapped"},
   {"aq_parent", (PyCFunction)module_aq_parent, METH_O,
    "aq_parent(ob) -- Get the parent of an object"},
-  {"aq_self", (PyCFunction)module_aq_self, METH_VARARGS, 
+  {"aq_self", (PyCFunction)module_aq_self, METH_O,
    "aq_self(ob) -- Get the object with the outermost wrapper removed"},
   {"aq_inner", (PyCFunction)module_aq_inner, METH_VARARGS, 
    "aq_inner(ob) -- "

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -414,7 +414,7 @@ Wrapper_special(Wrapper *self, char *name, PyObject *oname)
 
     switch(*name) {
         case 'b':
-            if (strcmp(name, "base") == 0) {
+            if (STR_EQ(name, "base")) {
                 r = get_base(OBJECT(self));
                 Py_INCREF(r);
                 return r;
@@ -422,7 +422,7 @@ Wrapper_special(Wrapper *self, char *name, PyObject *oname)
             break;
 
         case 'p':
-            if (strcmp(name, "parent") == 0) {
+            if (STR_EQ(name, "parent")) {
                 r = self->container ? self->container : Py_None;
                 Py_INCREF(r);
                 return r;
@@ -430,14 +430,14 @@ Wrapper_special(Wrapper *self, char *name, PyObject *oname)
             break;
 
         case 's':
-            if (strcmp(name, "self") == 0) {
+            if (STR_EQ(name, "self")) {
                 Py_INCREF(self->obj);
                 return self->obj;
             }
             break;
 
         case 'e':
-            if (strcmp(name, "explicit") == 0) {
+            if (STR_EQ(name, "explicit")) {
                 if (isExplicitWrapper(self)) {
                     Py_INCREF(self);
                     return OBJECT(self);
@@ -448,13 +448,13 @@ Wrapper_special(Wrapper *self, char *name, PyObject *oname)
             break;
 
         case 'a':
-            if (strcmp(name, "acquire") == 0) {
+            if (STR_EQ(name, "acquire")) {
                 return Py_FindAttr(OBJECT(self), oname);
             }
             break;
 
         case 'c':
-            if (strcmp(name, "chain") == 0) {
+            if (STR_EQ(name, "chain")) {
                 if ((r = PyList_New(0)) == NULL) {
                     return NULL;
                 }
@@ -473,9 +473,9 @@ Wrapper_special(Wrapper *self, char *name, PyObject *oname)
             break;
 
         case 'i':
-            if (strcmp(name, "inContextOf") == 0) {
+            if (STR_EQ(name, "inContextOf")) {
                 return Py_FindAttr(OBJECT(self), oname);
-            } else if (strcmp(name, "inner") == 0) {
+            } else if (STR_EQ(name, "inner")) {
                 r = get_inner(OBJECT(self));
                 Py_INCREF(r);
                 return r;
@@ -483,7 +483,7 @@ Wrapper_special(Wrapper *self, char *name, PyObject *oname)
             break;
 
         case 'u':
-            if (strcmp(name, "uncle") == 0) {
+            if (STR_EQ(name, "uncle")) {
                 return NATIVE_FROM_STRING("Bob");
             }
             break;

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -149,23 +149,24 @@ CallMethodArgs(PyObject *self, PyObject *name, char *format, ...)
 static PyObject *
 diff_to_bool(int diff, int op)
 {
-	PyObject *result;
-	int istrue;
+    PyObject *result;
+    int istrue;
 
-	switch (op) {
-		case Py_EQ: istrue = diff == 0; break;
-		case Py_NE: istrue = diff != 0; break;
-		case Py_LE: istrue = diff <= 0; break;
-		case Py_GE: istrue = diff >= 0; break;
-		case Py_LT: istrue = diff < 0; break;
-		case Py_GT: istrue = diff > 0; break;
-		default:
-			assert(! "op unknown");
-			istrue = 0; /* To shut up compiler */
-	}
-	result = istrue ? Py_True : Py_False;
-	Py_INCREF(result);
-	return result;
+    switch (op) {
+        case Py_EQ: istrue = diff == 0; break;
+        case Py_NE: istrue = diff != 0; break;
+        case Py_LE: istrue = diff <= 0; break;
+        case Py_GE: istrue = diff >= 0; break;
+        case Py_LT: istrue = diff < 0; break;
+        case Py_GT: istrue = diff > 0; break;
+        default:
+            assert(! "op unknown");
+            istrue = 0; /* To shut up compiler */
+    }
+
+    result = istrue ? Py_True : Py_False;
+    Py_INCREF(result);
+    return result;
 }
 
 static PyObject*
@@ -391,7 +392,7 @@ Wrapper_traverse(Wrapper *self, visitproc visit, void *arg)
     return 0;
 }
 
-static int 
+static int
 Wrapper_clear(Wrapper *self)
 {
     Py_CLEAR(self->obj);
@@ -400,7 +401,7 @@ Wrapper_clear(Wrapper *self)
 }
 
 static void
-Wrapper_dealloc(Wrapper *self)     
+Wrapper_dealloc(Wrapper *self)
 {
     Wrapper_clear(self);
     Py_TYPE(self)->tp_free(OBJECT(self));
@@ -494,7 +495,7 @@ Wrapper_special(Wrapper *self, char *name, PyObject *oname)
 
 static int
 apply_filter(PyObject *filter, PyObject *inst, PyObject *oname, PyObject *r,
-	     PyObject *extra, PyObject *orig)
+             PyObject *extra, PyObject *orig)
 {
     /* Calls the filter, passing arguments.
 
@@ -527,19 +528,19 @@ apply_filter(PyObject *filter, PyObject *inst, PyObject *oname, PyObject *r,
 }
 
 static PyObject *
-Wrapper_acquire(Wrapper *self, PyObject *oname, 
-		PyObject *filter, PyObject *extra, PyObject *orig,
-		int explicit, int containment);
+Wrapper_acquire(Wrapper *self, PyObject *oname,
+                PyObject *filter, PyObject *extra, PyObject *orig,
+                int explicit, int containment);
 
 static PyObject *
 Wrapper_findattr_name(Wrapper *self, char* name, PyObject *oname,
-		PyObject *filter, PyObject *extra, PyObject *orig,
-		int sob, int sco, int explicit, int containment);
+                      PyObject *filter, PyObject *extra, PyObject *orig,
+                      int sob, int sco, int explicit, int containment);
 
 static PyObject *
 Wrapper_findattr(Wrapper *self, PyObject *oname,
-		PyObject *filter, PyObject *extra, PyObject *orig,
-		int sob, int sco, int explicit, int containment)
+                 PyObject *filter, PyObject *extra, PyObject *orig,
+                 int sob, int sco, int explicit, int containment)
 /*
   Parameters:
 
@@ -572,8 +573,8 @@ Wrapper_findattr(Wrapper *self, PyObject *oname,
 
 static PyObject *
 Wrapper_findattr_name(Wrapper *self, char* name, PyObject *oname,
-		PyObject *filter, PyObject *extra, PyObject *orig,
-		int sob, int sco, int explicit, int containment)
+                      PyObject *filter, PyObject *extra, PyObject *orig,
+                      int sob, int sco, int explicit, int containment)
 /*
  Exactly the same as Wrapper_findattr, except that the incoming
  Python name string/unicode object has already been decoded
@@ -1093,7 +1094,7 @@ Wrapper_contains(PyObject *self, PyObject *v)
    Instead the base object needs to be checked and the wrapper must only
    be used when actually calling `__getitem__` or setting up a sequence
    iterator. */
-static PyObject * 
+static PyObject *
 Wrapper_iter(Wrapper *self)
 {
   PyObject *obj = self->obj;
@@ -1118,14 +1119,14 @@ Wrapper_iter(Wrapper *self)
 }
 
 static PySequenceMethods Wrapper_as_sequence = {
-	(lenfunc)Wrapper_length,		/*sq_length*/
-	Wrapper_add,		/*sq_concat*/
-	(ssizeargfunc)Wrapper_repeat,		/*sq_repeat*/
-	(ssizeargfunc)Wrapper_item,		/*sq_item*/
-	(ssizessizeargfunc)Wrapper_slice,		/*sq_slice*/
-	(ssizeobjargproc)Wrapper_ass_item,	/*sq_ass_item*/
-	(ssizessizeobjargproc)Wrapper_ass_slice,	/*sq_ass_slice*/
-	(objobjproc)Wrapper_contains,		/*sq_contains*/
+    (lenfunc)Wrapper_length,            /*sq_length*/
+    Wrapper_add,                        /*sq_concat*/
+    (ssizeargfunc)Wrapper_repeat,       /*sq_repeat*/
+    (ssizeargfunc)Wrapper_item,         /*sq_item*/
+    (ssizessizeargfunc)Wrapper_slice,   /*sq_slice*/
+    (ssizeobjargproc)Wrapper_ass_item,  /*sq_ass_item*/
+    (ssizessizeobjargproc)Wrapper_ass_slice,    /*sq_ass_slice*/
+    (objobjproc)Wrapper_contains,       /*sq_contains*/
 };
 
 /* -------------------------------------------------------------- */
@@ -1157,9 +1158,9 @@ Wrapper_ass_sub(PyObject *self, PyObject *key, PyObject *v)
 }
 
 static PyMappingMethods Wrapper_as_mapping = {
-  (lenfunc)Wrapper_length,		/*mp_length*/
-  (binaryfunc)Wrapper_subscript,	/*mp_subscript*/
-  (objobjargproc)Wrapper_ass_sub,	/*mp_ass_subscript*/
+    (lenfunc)Wrapper_length,        /*mp_length*/
+    (binaryfunc)Wrapper_subscript,  /*mp_subscript*/
+    (objobjargproc)Wrapper_ass_sub, /*mp_ass_subscript*/
 };
 
 /* -------------------------------------------------------------- */
@@ -1380,7 +1381,7 @@ static PyNumberMethods Wrapper_as_number = {
 
 
 static char *acquire_args[] = {"object", "name", "filter", "extra", "explicit",
-			       "default", "containment", NULL};
+                               "default", "containment", NULL};
 
 static PyObject *
 Wrapper_acquire_method(Wrapper *self, PyObject *args, PyObject *kw)
@@ -1605,7 +1606,7 @@ capi_aq_acquire(
     PyObject *self,
     PyObject *name,
     PyObject *filter,
-	PyObject *extra,
+    PyObject *extra,
     int explicit,
     PyObject *defalt,
     int containment)
@@ -1722,7 +1723,7 @@ module_aq_get(PyObject *r, PyObject *args)
 {
     PyObject *self, *name, *defalt = NULL;
     int containment = 0;
-  
+
     if (!PyArg_ParseTuple(args, "OO|Oi", &self, &name, &defalt, &containment)) {
         return NULL;
     }
@@ -1730,7 +1731,7 @@ module_aq_get(PyObject *r, PyObject *args)
     return capi_aq_get(self, name, defalt, containment);
 }
 
-static int 
+static int
 capi_aq_iswrapper(PyObject *self) {
     return isWrapper(self);
 }
@@ -1864,7 +1865,7 @@ capi_aq_chain(PyObject *self, int containment)
         }
         break;
     }
-  
+
     Py_XDECREF(self);
     return result;
 err:
@@ -1941,7 +1942,7 @@ module_aq_inContextOf(PyObject *ignored, PyObject *args)
 }
 
 static struct PyMethodDef methods[] = {
-  {"aq_acquire", (PyCFunction)module_aq_acquire, METH_VARARGS|METH_KEYWORDS, 
+  {"aq_acquire", (PyCFunction)module_aq_acquire, METH_VARARGS|METH_KEYWORDS,
    "aq_acquire(ob, name [, filter, extra, explicit]) -- "
    "Get an attribute, acquiring it if necessary"
   },
@@ -1958,7 +1959,7 @@ static struct PyMethodDef methods[] = {
   {"aq_inner", (PyCFunction)module_aq_inner, METH_O,
    "aq_inner(ob) -- "
    "Get the object with all but the innermost wrapper removed"},
-  {"aq_chain", (PyCFunction)module_aq_chain, METH_VARARGS, 
+  {"aq_chain", (PyCFunction)module_aq_chain, METH_VARARGS,
    "aq_chain(ob [, containment]) -- "
    "Get a list of objects in the acquisition environment"},
   {"aq_inContextOf", (PyCFunction)module_aq_inContextOf, METH_VARARGS,

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -1452,33 +1452,34 @@ static PyObject * capi_aq_inContextOf(PyObject *self, PyObject *o, int inner);
 static PyObject *
 Wrapper_inContextOf(Wrapper *self, PyObject *args)
 {
-  PyObject *o;
+    PyObject *o;
+    int inner = 1;
+    if (!PyArg_ParseTuple(args, "O|i", &o, &inner)) {
+        return NULL;
+    }
 
-  int inner=1;
-  UNLESS(PyArg_ParseTuple(args,"O|i",&o,&inner)) return NULL;
-
-  return capi_aq_inContextOf((PyObject*)self, o, inner);
+    return capi_aq_inContextOf(OBJECT(self), o, inner);
 }
 
 PyObject *
 Wrappers_are_not_picklable(PyObject *wrapper, PyObject *args)
 {
-  PyErr_SetString(PyExc_TypeError, 
-                  "Can't pickle objects in acquisition wrappers.");
-  return NULL;
+    PyErr_SetString(PyExc_TypeError,
+                    "Can't pickle objects in acquisition wrappers.");
+    return NULL;
 }
 
 static PyObject *
 Wrapper___getnewargs__(PyObject *self)
 {
-  return PyTuple_New(0);
+    return PyTuple_New(0);
 }
 
 static struct PyMethodDef Wrapper_methods[] = {
-  {"acquire", (PyCFunction)Wrapper_acquire_method, 
+  {"acquire", (PyCFunction)Wrapper_acquire_method,
    METH_VARARGS|METH_KEYWORDS,
    "Get an attribute, acquiring it if necessary"},
-  {"aq_acquire", (PyCFunction)Wrapper_acquire_method, 
+  {"aq_acquire", (PyCFunction)Wrapper_acquire_method,
    METH_VARARGS|METH_KEYWORDS,
    "Get an attribute, acquiring it if necessary"},
   {"aq_inContextOf", (PyCFunction)Wrapper_inContextOf, METH_VARARGS,
@@ -1492,104 +1493,92 @@ static struct PyMethodDef Wrapper_methods[] = {
   {"__reduce_ex__", (PyCFunction)Wrappers_are_not_picklable, METH_VARARGS,
    "Wrappers are not picklable"},
   {"__unicode__", (PyCFunction)Wrapper_unicode, METH_NOARGS,
-   "Unicode"},   
-  {NULL,		NULL}		/* sentinel */
+   "Unicode"},
+  {NULL,  NULL}
 };
 
 static PyExtensionClass Wrappertype = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-  "Acquisition.ImplicitAcquisitionWrapper",		/*tp_name*/
-  sizeof(Wrapper),       		/*tp_basicsize*/
-  0,					/*tp_itemsize*/
-  /* methods */
-  (destructor)Wrapper_dealloc,		/*tp_dealloc*/
-  (printfunc)0,				/*tp_print*/
-  (getattrfunc)0,			/*tp_getattr*/
-  (setattrfunc)0,			/*tp_setattr*/
-  0,	    			/*tp_compare*/
-  (reprfunc)Wrapper_repr,      		/*tp_repr*/
-  &Wrapper_as_number,			/*tp_as_number*/
-  &Wrapper_as_sequence,			/*tp_as_sequence*/
-  &Wrapper_as_mapping,			/*tp_as_mapping*/
-  (hashfunc)Wrapper_hash,      		/*tp_hash*/
-  (ternaryfunc)Wrapper_call,		/*tp_call*/
-  (reprfunc)Wrapper_str,       		/*tp_str*/
-  (getattrofunc)Wrapper_getattro,	/*tp_getattr with object key*/
-  (setattrofunc)Wrapper_setattro,      	/*tp_setattr with object key*/
-  /* tp_as_buffer      */ 0,
-  /* tp_flags          */ Py_TPFLAGS_DEFAULT 
-                          | Py_TPFLAGS_BASETYPE
-                          | Py_TPFLAGS_HAVE_GC
-#ifdef Py_TPFLAGS_HAVE_VERSION_TAG
-                          | Py_TPFLAGS_HAVE_VERSION_TAG
-#endif
-                          ,
-  "Wrapper object for implicit acquisition", /* Documentation string */
-  /* tp_traverse       */ (traverseproc)Wrapper_traverse,
-  /* tp_clear          */ (inquiry)Wrapper_clear,
-  /* tp_richcompare    */ (richcmpfunc)Wrapper_richcompare,
-  /* tp_weaklistoffset */ (long)0,
-  (getiterfunc)Wrapper_iter,		/*tp_iter*/
-  /* tp_iternext       */ (iternextfunc)0,
-  /* tp_methods        */ Wrapper_methods,
-  /* tp_members        */ 0,
-  /* tp_getset         */ 0,
-  /* tp_base           */ 0,
-  /* tp_dict           */ 0,
-  /* tp_descr_get      */ (descrgetfunc)Wrapper_descrget,
-  /* tp_descr_set      */ 0,
-  /* tp_dictoffset     */ 0,
-  /* tp_init           */ (initproc)Wrapper__init__,
-  /* tp_alloc          */ 0,
-  /* tp_new            */ Wrapper__new__
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "Acquisition.ImplicitAcquisitionWrapper",       /* tp_name */
+    sizeof(Wrapper),                                /* tp_basicsize */
+    0,                                              /* tp_itemsize */
+    (destructor)Wrapper_dealloc,                    /* tp_dealloc */
+    (printfunc)0,                                   /* tp_print */
+    (getattrfunc)0,                                 /* tp_getattr */
+    (setattrfunc)0,                                 /* tp_setattr */
+    0,                                              /* tp_compare */
+    (reprfunc)Wrapper_repr,                         /* tp_repr */
+    &Wrapper_as_number,                             /* tp_as_number */
+    &Wrapper_as_sequence,                           /* tp_as_sequence */
+    &Wrapper_as_mapping,                            /* tp_as_mapping */
+    (hashfunc)Wrapper_hash,                         /* tp_hash */
+    (ternaryfunc)Wrapper_call,                      /* tp_call */
+    (reprfunc)Wrapper_str,                          /* tp_str */
+    (getattrofunc)Wrapper_getattro,                 /* tp_getattro */
+    (setattrofunc)Wrapper_setattro,                 /* tp_setattro */
+    0,                                              /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
+          Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_HAVE_VERSION_TAG, /* tp_flags */
+    "Wrapper object for implicit acquisition",      /* tp_doc */
+    (traverseproc)Wrapper_traverse,                 /* tp_traverse */
+    (inquiry)Wrapper_clear,                         /* tp_clear */
+    (richcmpfunc)Wrapper_richcompare,               /* tp_richcompare */
+    0,                                              /* tp_weaklistoffset */
+    (getiterfunc)Wrapper_iter,                      /* tp_iter */
+    0,                                              /* tp_iternext */
+    Wrapper_methods,                                /* tp_methods */
+    0,                                              /* tp_members */
+    0,                                              /* tp_getset */
+    0,                                              /* tp_base */
+    0,                                              /* tp_dict */
+    (descrgetfunc)Wrapper_descrget,                 /* tp_descr_get */
+    0,                                              /* tp_descr_set */
+    0,                                              /* tp_dictoffset */
+    (initproc)Wrapper__init__,                      /* tp_init */
+    0,                                              /* tp_alloc */
+    Wrapper__new__                                  /* tp_new */
 };
 
 static PyExtensionClass XaqWrappertype = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-  "Acquisition.ExplicitAcquisitionWrapper",		/*tp_name*/
-  sizeof(Wrapper),       		/*tp_basicsize*/
-  0,					/*tp_itemsize*/
-  /* methods */
-  (destructor)Wrapper_dealloc,		/*tp_dealloc*/
-  (printfunc)0,				/*tp_print*/
-  (getattrfunc)0,			/*tp_getattr*/
-  (setattrfunc)0,			/*tp_setattr*/
-  0,    		/*tp_compare*/
-  (reprfunc)Wrapper_repr,      		/*tp_repr*/
-  &Wrapper_as_number,			/*tp_as_number*/
-  &Wrapper_as_sequence,			/*tp_as_sequence*/
-  &Wrapper_as_mapping,			/*tp_as_mapping*/
-  (hashfunc)Wrapper_hash,      		/*tp_hash*/
-  (ternaryfunc)Wrapper_call,		/*tp_call*/
-  (reprfunc)Wrapper_str,       		/*tp_str*/
-  (getattrofunc)Xaq_getattro,		/*tp_getattr with object key*/
-  (setattrofunc)Wrapper_setattro,      	/*tp_setattr with object key*/
-  /* tp_as_buffer      */ 0,
-  /* tp_flags          */ Py_TPFLAGS_DEFAULT 
-                          | Py_TPFLAGS_BASETYPE
-                          | Py_TPFLAGS_HAVE_GC
-#ifdef Py_TPFLAGS_HAVE_VERSION_TAG
-                          | Py_TPFLAGS_HAVE_VERSION_TAG
-#endif
-                          ,
-  "Wrapper object for implicit acquisition", /* Documentation string */
-  /* tp_traverse       */ (traverseproc)Wrapper_traverse,
-  /* tp_clear          */ (inquiry)Wrapper_clear,
-  /* tp_richcompare    */ (richcmpfunc)Wrapper_richcompare,
-  /* tp_weaklistoffset */ (long)0,
-  (getiterfunc)Wrapper_iter,		/*tp_iter*/
-  /* tp_iternext       */ (iternextfunc)0,
-  /* tp_methods        */ Wrapper_methods,
-  /* tp_members        */ 0,
-  /* tp_getset         */ 0,
-  /* tp_base           */ 0,
-  /* tp_dict           */ 0,
-  /* tp_descr_get      */ (descrgetfunc)Wrapper_descrget,
-  /* tp_descr_set      */ 0,
-  /* tp_dictoffset     */ 0,
-  /* tp_init           */ (initproc)Wrapper__init__,
-  /* tp_alloc          */ 0,
-  /* tp_new            */ Wrapper__new__
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "Acquisition.ExplicitAcquisitionWrapper",       /*tp_name*/
+    sizeof(Wrapper),                                /* tp_basicsize */
+    0,                                              /* tp_itemsize */
+    (destructor)Wrapper_dealloc,                    /* tp_dealloc */
+    (printfunc)0,                                   /* tp_print */
+    (getattrfunc)0,                                 /* tp_getattr */
+    (setattrfunc)0,                                 /* tp_setattr */
+    0,                                              /* tp_compare */
+    (reprfunc)Wrapper_repr,                         /* tp_repr */
+    &Wrapper_as_number,                             /* tp_as_number */
+    &Wrapper_as_sequence,                           /* tp_as_sequence */
+    &Wrapper_as_mapping,                            /* tp_as_mapping */
+    (hashfunc)Wrapper_hash,                         /* tp_hash */
+    (ternaryfunc)Wrapper_call,                      /* tp_call */
+    (reprfunc)Wrapper_str,                          /* tp_str */
+    (getattrofunc)Xaq_getattro,                     /* tp_getattro */
+    (setattrofunc)Wrapper_setattro,                 /* tp_setattro */
+    0,                                              /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
+          Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_HAVE_VERSION_TAG, /* tp_flags */
+    "Wrapper object for explicit acquisition",      /* tp_doc */
+    (traverseproc)Wrapper_traverse,                 /* tp_traverse */
+    (inquiry)Wrapper_clear,                         /* tp_clear */
+    (richcmpfunc)Wrapper_richcompare,               /* tp_richcompare */
+    0,                                              /* tp_weaklistoffset */
+    (getiterfunc)Wrapper_iter,                      /* tp_iter */
+    0,                                              /* tp_iternext */
+    Wrapper_methods,                                /* tp_methods */
+    0,                                              /* tp_members */
+    0,                                              /* tp_getset */
+    0,                                              /* tp_base */
+    0,                                              /* tp_dict */
+    (descrgetfunc)Wrapper_descrget,                 /* tp_descr_get */
+    0,                                              /* tp_descr_set */
+    0,                                              /* tp_dictoffset */
+    (initproc)Wrapper__init__,                      /* tp_init */
+    0,                                              /* tp_alloc */
+    Wrapper__new__                                  /* tp_new */
 };
 
 static PyObject *

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -508,22 +508,16 @@ Wrapper_findattr(Wrapper *self, PyObject *oname,
     attribute.
 */
 {
-  PyObject *tmp=NULL;
-  PyObject *result;
-  char *name="";
+  PyObject *tmp, *result;
 
   if ((tmp = convert_name(oname)) == NULL) {
       return NULL;
   }
-  name = PyBytes_AS_STRING(tmp);
 
-  result = Wrapper_findattr_name(self, name, oname, filter, extra, orig,
-                                 sob, sco, explicit, containment);
-
+  result = Wrapper_findattr_name(self, PyBytes_AS_STRING(tmp), oname, filter,
+                                 extra, orig, sob, sco, explicit, containment);
   Py_XDECREF(tmp);
-
   return result;
-
 }
 
 static PyObject *

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -20,14 +20,7 @@
 
 static ACQUISITIONCAPI AcquisitionCAPI;
 
-static void
-PyVar_Assign(PyObject **v,  PyObject *e)
-{
-  Py_XDECREF(*v);
-  *v=e;
-}
-
-#define ASSIGN(V,E) PyVar_Assign(&(V),(E))
+#define ASSIGN(dst, src) Py_XSETREF(dst, src)
 #define OBJECT(O) ((PyObject*)(O))
 
 /* sizeof("x") == 2 because of the '\0' byte. */

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -28,24 +28,11 @@ PyVar_Assign(PyObject **v,  PyObject *e)
 }
 
 #define ASSIGN(V,E) PyVar_Assign(&(V),(E))
-#define UNLESS(E) if (!(E))
-#define UNLESS_ASSIGN(V,E) ASSIGN(V,E); UNLESS(V)
 #define OBJECT(O) ((PyObject*)(O))
 
 /* sizeof("x") == 2 because of the '\0' byte. */
 #define STR_STARTSWITH(ob, pattern) ((strncmp(ob, pattern, sizeof(pattern) - 1) == 0))
 #define STR_EQ(ob, pattern) ((strcmp(ob, pattern) == 0))
-
-#if PY_VERSION_HEX < 0x02050000 && !defined(PY_SSIZE_T_MIN)
-typedef int Py_ssize_t;
-typedef Py_ssize_t (*lenfunc)(PyObject *);
-typedef PyObject *(*ssizeargfunc)(PyObject *, Py_ssize_t);
-typedef PyObject *(*ssizessizeargfunc)(PyObject *, Py_ssize_t, Py_ssize_t);
-typedef int(*ssizeobjargproc)(PyObject *, Py_ssize_t, PyObject *);
-typedef int(*ssizessizeobjargproc)(PyObject *, Py_ssize_t, Py_ssize_t, PyObject *);
-#define PY_SSIZE_T_MAX INT_MAX
-#define PY_SSIZE_T_MIN INT_MIN
-#endif
 
 static PyObject *py__add__, *py__sub__, *py__mul__, *py__div__,
   *py__mod__, *py__pow__, *py__divmod__, *py__lshift__, *py__rshift__,
@@ -60,7 +47,7 @@ static PyObject *py__add__, *py__sub__, *py__mul__, *py__div__,
   *py__iand__, *py__ixor__, *py__ior__, *py__floordiv__, *py__truediv__,
   *py__ifloordiv__, *py__itruediv__, *py__matmul__, *py__imatmul__, *py__idiv__;
 
-static PyObject *Acquired=0;
+static PyObject *Acquired = NULL;
 
 static void
 init_py_names(void)

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -1299,31 +1299,32 @@ Wrapper_nonzero(PyObject *self)
 }
 
 #ifndef PY3K
-static int 
+static int
 Wrapper_coerce(PyObject **self, PyObject **o)
 {
-  PyObject *m;
+    PyObject *m;
 
-  UNLESS (m=PyObject_GetAttr(*self, py__coerce__))
-    {
-      PyErr_Clear();
-      Py_INCREF(*self);
-      Py_INCREF(*o);
-      return 0;
+    if ((m=PyObject_GetAttr(*self, py__coerce__)) == NULL) {
+        PyErr_Clear();
+        Py_INCREF(*self);
+        Py_INCREF(*o);
+        return 0;
     }
 
-  ASSIGN(m, PyObject_CallFunction(m, "O", *o));
-  UNLESS (m) return -1;
+    ASSIGN(m, PyObject_CallFunction(m, "O", *o));
+    if (m == NULL) {
+        return -1;
+    }
 
-  UNLESS (PyArg_ParseTuple(m,"OO", self, o)) goto err;
-  Py_INCREF(*self);
-  Py_INCREF(*o);
-  Py_DECREF(m);
-  return 0;
+    if (!PyArg_ParseTuple(m, "OO", self, o)) {
+        Py_DECREF(m);
+        return -1;
+    }
 
-err:
-  Py_DECREF(m);
-  return -1;  
+    Py_INCREF(*self);
+    Py_INCREF(*o);
+    Py_DECREF(m);
+    return 0;
 }
 #endif
 


### PR DESCRIPTION
Give some love to _Acquistion.c

While porting this file to python3 I got the feeling that it needs some clean up.
Some functions were very hard to read and this mix of tabs/spaces and missing brackets made it even harder to edit. So I started naively by "lets have a look what can be improved" and in the end hardly a line left unchanged.

The vast majority of changes are clean ups like.
* Using consistently 4 spaces to indent.
* Replacing repeating code blocks with a function (like `get_inner`, 'get_base`, ..)
* Using more macros/functions coming from `Python.h`

The only functional change I did was to implement `__new__` on a C level.
This ensures that an *empty* wrapper is impossible to create. So as soon as you have a Wrapper object you can rely on `self->obj` being set. I cannot see an use case were an empty wrapper is desired. This change made it possible to simplify the code a lot.
As far as I can see the python version is already doing it that way too: https://github.com/zopefoundation/Acquisition/blob/master/src/Acquisition/__init__.py#L361

My biggest fear are problems with refcount (=> memory leaks). So I applied this patch to the doctest module https://bugs.python.org/file10060/reset_globs.patch to use the `--repeat` and `--report-refcounts` of zope.testrunner.

Repeating the tests several 1000 times (it was running for 2 hours) did not show any growth of memory  (RSS) nor refcounts. So I feel pretty safe here.

I also used this branch to run the unittests of Zope and everything is OK there too.

There are also changes which should fix potential segfaults / memory leaks.
https://github.com/zopefoundation/Acquisition/commit/12c446c2051d1be000e34467d612c297f93ec62f
https://github.com/zopefoundation/Acquisition/commit/acaee010e0e4778559b483f06fef4ad7f3efcef1