### PR TITLE
The name used for capsule creation must be equal to import.

### DIFF
--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -2050,7 +2050,7 @@ module_init(void)
     AcquisitionCAPI.AQ_Inner = capi_aq_inner;
     AcquisitionCAPI.AQ_Chain = capi_aq_chain;
 
-    api = PyCapsule_New(&AcquisitionCAPI, "AcquisitionCAPI", NULL);
+    api = PyCapsule_New(&AcquisitionCAPI, "Acquisition.AcquisitionCAPI", NULL);
 
     PyDict_SetItemString(d, "AcquisitionCAPI", api);
     Py_DECREF(api);


### PR DESCRIPTION
PyCapsule_IsValid checks if the name used at PyCapsule_New is equal to
the name used in PyCapsule_Import.