### PR TITLE
Convert more doctests into unittests.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,7 +170,7 @@ Here's an example::
 
   >>> from Acquisition import Explicit
 
-  >>> class HandyForTesting:
+  >>> class HandyForTesting(object):
   ...     def __init__(self, name):
   ...         self.name = name
   ...     def __str__(self):

--- a/src/Acquisition/tests.py
+++ b/src/Acquisition/tests.py
@@ -335,7 +335,7 @@ def test_story():
 
     For example, in:
 
-    >>> class HandyForTesting:
+    >>> class HandyForTesting(object):
     ...     def __init__(self, name): self.name=name
     ...     def __str__(self):
     ...       return "%s(%s)" % (self.name, self.__class__.__name__)
@@ -1605,7 +1605,7 @@ class TestPickle(unittest.TestCase):
     def test_cant_pickle_acquisition_wrappers_classic(self):
         import pickle
 
-        class X:
+        class X(object):
             def __getstate__(self):
                 return 1
 
@@ -1682,7 +1682,7 @@ class TestPickle(unittest.TestCase):
         except ImportError:
             import pickle as cPickle
 
-        class X:
+        class X(object):
             _p_oid = '1234'
 
             def __getstate__(self):

--- a/src/Acquisition/tests.py
+++ b/src/Acquisition/tests.py
@@ -3450,25 +3450,7 @@ def test_suite():
 
     suites = [
         DocTestSuite(),
-        unittest.makeSuite(TestCreatingWrappers),
-        unittest.makeSuite(TestPickle),
-        unittest.makeSuite(TestInterfaces),
-        unittest.makeSuite(TestMixin),
-        unittest.makeSuite(TestGC),
-        unittest.makeSuite(TestAqParentParentInteraction),
-        unittest.makeSuite(TestParentCircles),
-        unittest.makeSuite(TestBugs),
-        unittest.makeSuite(TestSpecialNames),
-        unittest.makeSuite(TestWrapper),
-        unittest.makeSuite(TestOf),
-        unittest.makeSuite(TestAQInContextOf),
-        unittest.makeSuite(TestCircles),
-        unittest.makeSuite(TestAcquire),
-        unittest.makeSuite(TestCooperativeBase),
-        unittest.makeSuite(TestImplicitWrappingGetattribute),
-        unittest.makeSuite(TestUnicode),
-        unittest.makeSuite(TestProxying),
-        unittest.makeSuite(TestCompilation),
+        unittest.defaultTestLoader.loadTestsFromName(__name__),
     ]
 
     # This file is only available in a source checkout, skip it


### PR DESCRIPTION
Also use `unittest.skipIf/Unless` to skip tests, so the test count is the same in all test combinations.

Unitests make up ~50% of the tests now, up from ~30% :)