### PR TITLE
call PyObject_GC_UnTrack() in tp_dealloc()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,13 @@ python:
     - 2.6
     - 2.7
 install:
-    - python bootstrap.py
-    - bin/buildout
+    - pip install zc.buildout==2.3.1
+    - buildout
 script:
     - bin/test -v1
 notifications:
     email: false
+cache:
+  pip: true
+  directories:
+    - eggs/

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changelog
 2.13.12 (unreleased)
 --------------------
 
+- Fix the extremely rare potential for a crash when the C extensions
+  are in use. See `issue 21 <https://github.com/zopefoundation/Acquisition/issues/21>`_.
+
 
 2.13.11 (2016-09-05)
 --------------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,5 +1,7 @@
 [buildout]
 develop = .
+extends = https://raw.githubusercontent.com/zopefoundation/Zope/2.13/version_ranges.cfg
+index = https://pypi.python.org/simple/
 parts = interpreter test
 
 [interpreter]

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -291,8 +291,9 @@ Wrapper_clear(Wrapper *self)
 static void
 Wrapper_dealloc(Wrapper *self)     
 {
-  Wrapper_clear(self);
-  self->ob_type->tp_free((PyObject*)self);
+    PyObject_GC_UnTrack(OBJECT(self));
+    Wrapper_clear(self);
+    self->ob_type->tp_free((PyObject*)self);
 }
 
 static PyObject *


### PR DESCRIPTION
Backport #22 to 2.13 branch.

This relates to zopefoundation/Zope#229.