### PR TITLE
On CPython do not omit compiling C code when `PURE_PYTHON` is required.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 4.9 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- On CPython no longer omit compiling the C code when ``PURE_PYTHON`` is
+  required. Just evaluate it at runtime.
+  (`#53 <https://github.com/zopefoundation/Acquisition/issues/53>`_)
 
 
 4.8 (2021-07-20)

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,7 @@ with open('CHANGES.rst') as f:
 # PyPy won't build the extension.
 py_impl = getattr(platform, 'python_implementation', lambda: None)
 is_pypy = py_impl() == 'PyPy'
-is_pure = 'PURE_PYTHON' in os.environ
-if is_pypy or is_pure:
+if is_pypy:
     ext_modules = []
 else:
     ext_modules = [
@@ -53,7 +52,9 @@ setup(
     classifiers=[
         "Development Status :: 6 - Mature",
         "Environment :: Web Environment",
-        "Framework :: Zope2",
+        "Framework :: Zope :: 2",
+        "Framework :: Zope :: 4",
+        "Framework :: Zope :: 5",
         "License :: OSI Approved :: Zope Public License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",

--- a/src/Acquisition/__init__.py
+++ b/src/Acquisition/__init__.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, print_function
 
 
 import os
-import operator
 import platform
 import sys
 import types
@@ -18,12 +17,9 @@ from .interfaces import IAcquirer
 from .interfaces import IAcquisitionWrapper
 
 IS_PYPY = getattr(platform, 'python_implementation', lambda: None)() == 'PyPy'
-IS_PURE = 'PURE_PYTHON' in os.environ
-
-
+IS_PURE = int(os.environ.get('PURE_PYTHON', '0'))
+CAPI = not (IS_PYPY or IS_PURE)
 Acquired = "<Special Object Used to Force Acquisition>"
-
-
 _NOT_FOUND = object()  # marker
 
 ###
@@ -917,7 +913,7 @@ def aq_inContextOf(self, o, inner=True):
     return False
 
 
-if not (IS_PYPY or IS_PURE):  # pragma: no cover
+if CAPI:  # pragma: no cover
     # Make sure we can import the C extension of our dependency.
     from ExtensionClass import _ExtensionClass  # NOQA
     from ._Acquisition import *  # NOQA

--- a/src/Acquisition/tests.py
+++ b/src/Acquisition/tests.py
@@ -35,6 +35,7 @@ from Acquisition import (  # NOQA
     aq_self,
     Explicit,
     Implicit,
+    CAPI,
     IS_PYPY,
     IS_PURE,
     _Wrapper,
@@ -3282,18 +3283,15 @@ class TestProxying(unittest.TestCase):
 
         self.assertEqual(base.derived(1, k=2), (42, 1, 2))
 
-        if not IS_PYPY:
-            # XXX: This test causes certain versions
-            # of PyPy to segfault (at least 2.6.0-alpha1)
-            class NotCallable(base_class):
-                pass
+        class NotCallable(base_class):
+            pass
 
-            base.derived = NotCallable()
-            try:
-                base.derived()
-                self.fail("Not callable")
-            except (TypeError, AttributeError):
-                pass
+        base.derived = NotCallable()
+        try:
+            base.derived()
+            self.fail("Not callable")
+        except (TypeError, AttributeError):
+            pass
 
     def test_implicit_proxy_call(self):
         self._check_call()
@@ -3416,19 +3414,18 @@ class TestProxying(unittest.TestCase):
 
 class TestCompilation(unittest.TestCase):
 
-    def test_compile(self):
-        if IS_PYPY or IS_PURE:
-            # the test wants to verify that in a Python only
-            # setup, the C extension is not generated.
-            # However, for efficiency reasons, the tests are usually
-            # run in a shared environment, and the test would fail
-            # as the C extension is available
-            pass
-##            with self.assertRaises((AttributeError, ImportError)):
-##                from Acquisition import _Acquisition
-        else:
+    def test_compilation(self):
+        self.assertEqual(CAPI, not (IS_PYPY or IS_PURE))
+        try:
             from Acquisition import _Acquisition
+            cExplicit = _Acquisition.Explicit
+        except ImportError:
+            cExplicit = None  # PyPy never has a C module.
+        if CAPI:  # pragma: no cover
             self.assertTrue(hasattr(_Acquisition, 'AcquisitionCAPI'))
+            self.assertEqual(Explicit, cExplicit)
+        else:
+            self.assertNotEqual(Explicit, cExplicit)
 
 
 def test_suite():


### PR DESCRIPTION
Just evaluate it at runtime.

Fixes #53.

Note to self: Squash merge this PR after approval because of typo in commit message.
