### PR TITLE
Improve interface documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changelog
 - Fix bug in the ``PURE_PYTHON`` version affecting ``aq_acquire`` applied
   to a class with a filter.
 
+- Improve interface documentation
+
 
 4.9 (2021-08-19)
 ----------------

--- a/src/Acquisition/interfaces.py
+++ b/src/Acquisition/interfaces.py
@@ -13,6 +13,9 @@
 """Acquisition z3 interfaces.
 
 $Id$
+
+For details, see
+`README.rst <https://github.com/zopefoundation/Acquisition#readme>`_
 """
 
 from zope.interface import Attribute
@@ -32,11 +35,69 @@ class IAcquirer(Interface):
 class IAcquisitionWrapper(Interface):
 
     """Wrapper object for acquisition.
+
+    A wrapper encapsulates an object, ``aq_self``, and a parent ``aq_parent``.
+    Both of them can in turn be wrappers.
+
+    Informally, the wrapper indicates that the object has been
+    accessed via the parent.
+
+    The wrapper essentially behaves like the object but may (in
+    some cases) also show behavior of the parent.
+
+    A wrapper is called an "inner wrapper" if its object is not
+    itself a wrapper. In this case, the parent is called the object's
+    container.
+
+    There are 2 kinds of wrappers - implicit and explicit wrappers:
+    Implicit wrappers search attributes in the parent by default
+    in contrast to explicit wrappers.
     """
 
     def aq_acquire(name, filter=None, extra=None, explicit=True, default=0,
-                   containment=0):
+                   containment=False):
         """Get an attribute, acquiring it if necessary.
+
+        The search first searches in the object and if this search
+        is unsuccessful, it may continue the search in the parent.
+
+        When the attribute is found and *filter* is not None,
+        *filter* is called with the parameters:
+
+          self
+            the object ``aq_acquire`` was called on
+
+          container
+            the container the attribute was found in
+
+          *name*
+            ``aq_acquire`` parameter
+
+          value
+            the attribute value
+            
+          *extra*
+            ``aq_acquire`` parameter
+
+        If the call returns true, *value* is returned,
+        otherwise the search continues.
+
+        *explicit* controls whether the attribute is also searched
+        in the parent. This is always the case for implicit
+        wrappers. For explicit wrappers, the parent
+        is only searched if *explicit* is true.
+
+        *default* controls what happens when the attribute was not found.
+        In this case, *default* is returned when it was passed;
+        otherwise, ``AttributeError`` is raised.
+        (Note: in contradiction to the signature above, *default* has
+        actually a "not given" marker as default, not ``0``).
+
+        *containment* controls whether the search is restricted
+        to the "containment hierarchy". In the corresponding search,
+        the parent of a wrapper *w* is only searched if *w* is an inner
+        wrapper, i.e. if the object of *w* is not a wrapper and the parent
+        is the object's container.
         """
 
     def aq_inContextOf(obj, inner=1):

--- a/src/Acquisition/interfaces.py
+++ b/src/Acquisition/interfaces.py
@@ -10,9 +10,7 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-"""Acquisition z3 interfaces.
-
-$Id$
+"""Acquisition interfaces.
 
 For details, see
 `README.rst <https://github.com/zopefoundation/Acquisition#readme>`_
@@ -62,7 +60,7 @@ class IAcquisitionWrapper(Interface):
         is unsuccessful, it may continue the search in the parent.
 
         When the attribute is found and *filter* is not None,
-        *filter* is called with the parameters:
+        *filter* is called with the following parameters:
 
           self
             the object ``aq_acquire`` was called on
@@ -79,7 +77,7 @@ class IAcquisitionWrapper(Interface):
           *extra*
             ``aq_acquire`` parameter
 
-        If the call returns true, *value* is returned,
+        If the call returns ``True``, *value* is returned,
         otherwise the search continues.
 
         *explicit* controls whether the attribute is also searched


### PR DESCRIPTION
Working on https://github.com/zopefoundation/AccessControl/pull/120
I found that the Python implementation of `Acquisition` has a bug in `aq_acquire` when a filter is involved. To create a failing test, I looked for documentation about filters for `aq_acquire`. My first choice in such a case is always the interface description but `Acquisition.interfaces` was not very informative.

This PR improves the interface documentation: it adds a reference to https://github.com/zopefoundation/Acquisition#readme and copies parts thereof into the interface description (slightly reworded). The intention is that reading the interface typically provides all relevant information without the need to look elsewhere.