### PR TITLE
PURE_PYTHON: fix `aq_acquire` bug for class with filter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 4.10 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fix bug in the ``PURE_PYTHON`` version affecting ``aq_acquire`` applied
+  to a class with a filter.
 
 
 4.9 (2021-08-19)

--- a/src/Acquisition/__init__.py
+++ b/src/Acquisition/__init__.py
@@ -382,7 +382,17 @@ class _Wrapper(ExtensionClass.Base):
             # so that if it has methods that use `object.__getattribute__`
             # they still work. Note that because we have slots,
             # we won't interfere with the contents of that dict.
-            object.__setattr__(inst, '__dict__', obj.__dict__)
+            od = obj.__dict__
+            if not isinstance(od, dict):
+                # Python 3 refuses to set ``__dict__`` to a non dict
+                # thus, convert
+                # Note: later changes to ``od`` will not be
+                # reflected by the wrapper. But, it is rare
+                # that ``od`` is not a dict (usually for class objects)
+                # and wrappers are transient entities. Thus, the
+                # risk should not be too high.
+                od = dict(od)
+            object.__setattr__(inst, '__dict__', od)
         return inst
 
     def __init__(self, obj, container):

--- a/src/Acquisition/__init__.py
+++ b/src/Acquisition/__init__.py
@@ -761,7 +761,7 @@ class _Acquirer(ExtensionClass.Base):
         except AttributeError:
             # the doctests have very specific error message
             # requirements (but at least we can preserve the traceback)
-            _, _, tb = sys.exc_info()
+            tb = sys.exc_info()[2]
             try:
                 _reraise(AttributeError, AttributeError(name), tb)
             finally:

--- a/src/Acquisition/tests.py
+++ b/src/Acquisition/tests.py
@@ -2545,6 +2545,17 @@ class TestWrapper(unittest.TestCase):
             with self.assertRaises(TypeError):
                 bytes(wrapper)
 
+    def test_aq_acquire_with_class_and_filter(self):
+        class C(object):
+            a = 1
+        allow = lambda *args: True
+        deny = lambda *args: False
+        self.assertEqual(aq_acquire(C, "a", allow), C.a)
+        with self.assertRaises(AttributeError):
+            aq_acquire(C, "a", deny)
+        with self.assertRaises(AttributeError):
+            aq_acquire(C, "b")
+
 
 class TestOf(unittest.TestCase):
 


### PR DESCRIPTION
The tests involved in https://github.com/zopefoundation/AccessControl/pull/120 revealed a bug in the PURE_PYTHON implementation of `Acquisition.aq_acquire` when applied to a class object and called with a filter.

The bug occurs because for a class object `C`, `C.__dict__` is not a dict (but a proxy). When a wrapper is constructed, the wrapper's `__dict__` is set to the object's `__dict__`. This fails in some Python versions for non dicts.

This PR checks for non dicts and creates a dict copy in this case. This allows to wrap class objects. However, because the wrapper's `__dict__` no longer is the class' `__dict__` but a copy, surprises may result.

An alternative would be to forbid the wrapping of objects with non dict `__dict__` and avoid for those objects the artificial wrapper creation in `aq_acquire` (it is there primarily to avoid code duplication).