### PR TITLE
Preliminary support for Python 3.13a3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,23 +96,24 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "pypy-3.9"
+          - "pypy-3.10"
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13.0-alpha - 3.13.0"
         os: [ubuntu-20.04, macos-11]
         exclude:
           - os: macos-11
-            python-version: "pypy-3.9"
+            python-version: "pypy-3.10"
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       ###
@@ -134,7 +135,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
+      - name: Install Build Dependencies (3.13.0-alpha - 3.13.0)
+        if: matrix.python-version == '3.13.0-alpha - 3.13.0'
+        run: |
+          pip install -U pip
+          pip install -U setuptools wheel twine
+          # cffi will probably have no public release until a Python 3.13 beta
+          # or even RC release, see https://github.com/python-cffi/cffi/issues/23
+          pip install -U "cffi @ https://github.com/python-cffi/cffi/archive/refs/heads/main.zip"
+          # twine has no release for 3.13, yet, see https://github.com/pypa/twine/issues/1030
+          pip install -U "git+https://github.com/pypa/twine.git#egg=twine"
       - name: Install Build Dependencies
+        if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine cffi
@@ -178,7 +190,15 @@ jobs:
           python setup.py build_ext -i
           python setup.py bdist_wheel
 
+      - name: Install Acquisition and dependencies (3.13.0-alpha - 3.13.0)
+        if: matrix.python-version == '3.13.0-alpha - 3.13.0'
+        run: |
+          # Install to collect dependencies into the (pip) cache.
+          # Use "--pre" here because dependencies with support for this future
+          # Python release may only be available as pre-releases
+          pip install --pre .[test]
       - name: Install Acquisition and dependencies
+        if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |
           # Install to collect dependencies into the (pip) cache.
           pip install .[test]
@@ -190,7 +210,7 @@ jobs:
       - name: Upload Acquisition wheel (macOS x86_64)
         if: >
           startsWith(runner.os, 'Mac')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Acquisition-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/*x86_64.whl
@@ -199,7 +219,7 @@ jobs:
           startsWith(runner.os, 'Mac')
           && !(startsWith(matrix.python-version, 'pypy')
                || matrix.python-version == '3.7')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           # The arm64 wheel is uploaded with a different name just so it can be
           # manually downloaded when desired. The wheel itself *cannot* be tested
@@ -209,7 +229,7 @@ jobs:
       - name: Upload Acquisition wheel (all other platforms)
         if: >
           !startsWith(runner.os, 'Mac')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Acquisition-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/*whl
@@ -222,6 +242,7 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
+          && !startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -234,23 +255,24 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "pypy-3.9"
+          - "pypy-3.10"
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13.0-alpha - 3.13.0"
         os: [ubuntu-20.04, macos-11]
         exclude:
           - os: macos-11
-            python-version: "pypy-3.9"
+            python-version: "pypy-3.10"
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       ###
@@ -273,11 +295,29 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Download Acquisition wheel
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Acquisition-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
+      - name: Install Acquisition 3.13.0-alpha - 3.13.0
+        if: ${{ startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0') }}
+        run: |
+          pip install -U wheel setuptools
+          # cffi will probably have no public release until a beta or even RC
+          # version of Python 3.13, see https://github.com/python-cffi/cffi/issues/23
+          pip install -U 'cffi @ https://github.com/python-cffi/cffi/archive/refs/heads/main.zip ; platform_python_implementation == "CPython"'
+          # coverage has a wheel on PyPI for a future python version which is
+          # not ABI compatible with the current one, so build it from sdist:
+          pip install -U --no-binary :all: coverage
+          # Unzip into src/ so that testrunner can find the .so files
+          # when we ask it to load tests from that directory. This
+          # might also save some build time?
+          unzip -n dist/Acquisition-*whl -d src
+          # Use "--pre" here because dependencies with support for this future
+          # Python release may only be available as pre-releases
+          pip install --pre -U -e .[test]
       - name: Install Acquisition
+        if: ${{ !startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0') }}
         run: |
           pip install -U wheel setuptools
           pip install -U coverage
@@ -325,9 +365,9 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       ###
@@ -350,7 +390,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Download Acquisition wheel
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Acquisition-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
@@ -378,9 +418,9 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       ###
@@ -430,7 +470,7 @@ jobs:
           bash .manylinux.sh
 
       - name: Upload Acquisition wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: wheelhouse/*whl
           name: manylinux_${{ matrix.image }}_wheels.zip

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -28,6 +28,7 @@ yum -y install libffi-devel
 
 tox_env_map() {
     case $1 in
+        *"cp313"*) echo 'py313';;
         *"cp37"*) echo 'py37';;
         *"cp38"*) echo 'py38';;
         *"cp39"*) echo 'py39';;
@@ -41,14 +42,20 @@ tox_env_map() {
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     if \
+       [[ "${PYBIN}" == *"cp313"* ]] || \
        [[ "${PYBIN}" == *"cp311"* ]] || \
        [[ "${PYBIN}" == *"cp312"* ]] || \
        [[ "${PYBIN}" == *"cp37"* ]] || \
        [[ "${PYBIN}" == *"cp38"* ]] || \
        [[ "${PYBIN}" == *"cp39"* ]] || \
        [[ "${PYBIN}" == *"cp310"* ]] ; then
-        "${PYBIN}/pip" install -e /io/
-        "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+        if [[ "${PYBIN}" == *"cp313"* ]] ; then
+            "${PYBIN}/pip" install --pre -e /io/
+            "${PYBIN}/pip" wheel /io/ --pre -w wheelhouse/
+        else
+            "${PYBIN}/pip" install -e /io/
+            "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+        fi
         if [ `uname -m` == 'aarch64' ]; then
           cd /io/
           ${PYBIN}/pip install tox

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "a361e1fd"
+commit-id = "e45966cd"
 
 [python]
 with-windows = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 5.2 (unreleased)
 ----------------
 
+- Add preliminary support for Python 3.13 as of 3.13a3.
+
 
 5.1 (2023-10-05)
 ----------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,9 @@ environment:
     - python: 310-x64
     - python: 311-x64
     - python: 312-x64
+    # `multibuild` cannot install non-final versions as they are not on
+    # ftp.python.org, so we skip Python 3.13 until its final release:
+    # - python: 313-x64
 
 install:
   - "SET PYTHONVERSION=%PYTHON%"

--- a/src/Acquisition/_Acquisition.c
+++ b/src/Acquisition/_Acquisition.c
@@ -118,7 +118,7 @@ CallMethod(PyObject *self, PyObject *name, PyObject *args, PyObject *kwargs)
         return NULL;
     }
 
-    result = PyEval_CallObjectWithKeywords(callable, args, kwargs);
+    result = PyObject_Call(callable, args, kwargs);
 
     Py_DECREF(callable);
     return result;

--- a/src/Acquisition/tests.py
+++ b/src/Acquisition/tests.py
@@ -1498,26 +1498,20 @@ class TestPickle(unittest.TestCase):
 
         # Check custom pickler with a persistent_id method matching
         # the semantics in ZODB.serialize.ObjectWriter.persistent_id:
+        class Pickler(cPickle.Pickler):
+            def persistent_id(self, obj):
+                if not hasattr(obj, '_p_oid'):
+                    return None
+                klass = type(obj)
+                oid = obj._p_oid
+                if hasattr(klass, '__getnewargs__'):
+                    # Coverage, make sure it can be called
+                    assert klass.__getnewargs__(obj) == ()
+                    return oid
+                return 'class_and_oid', klass
 
         file = BytesIO()
-        pickler = cPickle.Pickler(file, 1)
-
-        def persistent_id(obj):
-            if not hasattr(obj, '_p_oid'):
-                return None
-            klass = type(obj)
-            oid = obj._p_oid
-            if hasattr(klass, '__getnewargs__'):
-                # Coverage, make sure it can be called
-                assert klass.__getnewargs__(obj) == ()
-                return oid
-            return 'class_and_oid', klass
-
-        try:
-            pickler.inst_persistent_id = persistent_id
-        except AttributeError:
-            pass
-        pickler.persistent_id = persistent_id
+        pickler = Pickler(file, 1)
         pickler.dump(w)
         state = file.getvalue()
         self.assertTrue(b'1234' in state)
@@ -1558,25 +1552,18 @@ class TestPickle(unittest.TestCase):
 
         # Check custom pickler with a persistent_id method matching
         # the semantics in ZODB.serialize.ObjectWriter.persistent_id:
+        class Pickler(cPickle.Pickler):
+            def persistent_id(self, obj):
+                if not hasattr(obj, '_p_oid'):
+                    return None
+                klass = type(obj)
+                oid = obj._p_oid
+                if hasattr(klass, '__getnewargs__'):
+                    return oid
+                return 'class_and_oid', klass
 
         file = BytesIO()
-        pickler = cPickle.Pickler(file, 1)
-
-        def persistent_id(obj):
-            if not hasattr(obj, '_p_oid'):
-                return None
-            klass = type(obj)
-            oid = obj._p_oid
-            if hasattr(klass, '__getnewargs__'):
-                return oid
-            return 'class_and_oid', klass
-
-        try:
-            pickler.inst_persistent_id = persistent_id
-        except AttributeError:
-            pass
-
-        pickler.persistent_id = persistent_id
+        pickler = Pickler(file, 1)
         pickler.dump(w)
         state = file.getvalue()
         self.assertTrue(b'1234' in state)

--- a/tox.ini
+++ b/tox.ini
@@ -10,11 +10,13 @@ envlist =
     py310,py310-pure
     py311,py311-pure
     py312,py312-pure
+    py313,py313-pure
     pypy3
     coverage
 
 [testenv]
 usedevelop = true
+pip_pre = py313: true
 deps =
 setenv =
     pure: PURE_PYTHON=1
@@ -39,14 +41,36 @@ commands =
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}
     coverage html -i
     coverage report -i -m --fail-under=96
+[testenv:release-check]
+description = ensure that the distribution is ready to release
+basepython = python3
+skip_install = true
+deps =
+    twine
+    build
+    check-manifest
+    check-python-versions >= 0.20.0
+    wheel
+commands_pre =
+commands =
+    check-manifest
+    check-python-versions
+    python -m build --sdist --no-isolation
+    twine check dist/*
 
 [testenv:lint]
 basepython = python3
 skip_install = true
-commands =
-    check-manifest
-    check-python-versions
 deps =
-    check-manifest
-    check-python-versions >= 0.19.1
-    wheel
+    isort
+commands =
+    isort --check-only --diff {toxinidir}/src {toxinidir}/setup.py
+
+[testenv:isort-apply]
+basepython = python3
+skip_install = true
+commands_pre =
+deps =
+    isort
+commands =
+    isort {toxinidir}/src {toxinidir}/setup.py []


### PR DESCRIPTION
Open issues:

- [X] Fixes #55 – replace deprecated C function
- [x] Error in test test_cant_persist_acquisition_wrappers_classic (Acquisition.tests.TestPickle.test_cant_persist_acquisition_wrappers_classic)
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/case.py", line 636, in run
    self._callTestMethod(testMethod)
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
  File "/Users/runner/work/Acquisition/Acquisition/src/Acquisition/tests.py", line 1520, in test_cant_persist_acquisition_wrappers_classic
    pickler.persistent_id = persistent_id
AttributeError: '_pickle.Pickler' object attribute 'persistent_id' is read-only
- [x] Error in test test_cant_persist_acquisition_wrappers_newstyle (Acquisition.tests.TestPickle.test_cant_persist_acquisition_wrappers_newstyle)
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/case.py", line 6[36](https://github.com/zopefoundation/Acquisition/actions/runs/7760931015/job/21168908781?pr=68#step:9:37), in run
    self._callTestMethod(testMethod)
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
  File "/Users/runner/work/Acquisition/Acquisition/src/Acquisition/tests.py", line 1579, in test_cant_persist_acquisition_wrappers_newstyle
    pickler.persistent_id = persistent_id
AttributeError: '_pickle.Pickler' object attribute 'persistent_id' is read-only