### PR TITLE
Add preliminary support for Python 3.15 as of 3.15b1.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,7 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
+          - "3.15"
         os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
         exclude:
           - os: macos-latest
@@ -146,7 +147,13 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ matrix.python-version }}
 
 
+      - name: Install Build Dependencies (3.15)
+        if: startsWith(matrix.python-version, '3.15')
+        run: |
+          pip install -U pip
+          pip install -U "setuptools >= 78.1.1,< 82" wheel twine cffi pycparser
       - name: Install Build Dependencies
+        if: ${{ !startsWith(matrix.python-version, '3.15') }}
         run: |
           pip install -U pip
           pip install -U "setuptools >= 78.1.1,< 82" wheel twine
@@ -194,7 +201,15 @@ jobs:
         run: |
           python setup.py sdist
 
+      - name: Install Acquisition and dependencies (3.15)
+        if: startsWith(matrix.python-version, '3.15')
+        run: |
+          # Install to collect dependencies into the (pip) cache.
+          # Use "--pre" here because dependencies with support for this future
+          # Python release may only be available as pre-releases
+          pip install --pre .[test]
       - name: Install Acquisition and dependencies
+        if: ${{ !startsWith(matrix.python-version, '3.15') }}
         run: |
           # Install to collect dependencies into the (pip) cache.
           pip install -U pip "setuptools >= 78.1.1,< 82"
@@ -258,6 +273,7 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
+          - "3.15"
         os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
         exclude:
           - os: macos-latest
@@ -322,7 +338,23 @@ jobs:
         with:
           name: Acquisition-${{ runner.os }}-${{ matrix.python-version }}-${{ runner.arch }}.whl
           path: dist/
+      - name: Install Acquisition ${{ matrix.python-version }}
+        if: startsWith(matrix.python-version, '3.15')
+        run: |
+          pip install -U wheel "setuptools >= 78.1.1,< 82"
+          # coverage might have a wheel on PyPI for a future python version which is
+          # not ABI compatible with the current one, so build it from sdist:
+          pip install -U --no-binary :all: coverage[toml]
+          # Unzip into src/ so that testrunner can find the .so files
+          # when we ask it to load tests from that directory. This
+          # might also save some build time?
+          ls -l dist/
+          unzip -n dist/*.whl -d src
+          # Use "--pre" here because dependencies with support for this future
+          # Python release may only be available as pre-releases
+          pip install --pre -e .[test]
       - name: Install Acquisition
+        if: ${{ !startsWith(matrix.python-version, '3.15') }}
         run: |
           pip install -U wheel "setuptools >= 78.1.1,< 82"
           pip install -U coverage[toml]
@@ -350,7 +382,7 @@ jobs:
       - name: Submit to Coveralls
         # This is a container action, which only runs on Linux.
         if: ${{ startsWith(runner.os, 'Linux') }}
-        uses: AndreMiras/coveralls-python-action@develop
+        uses: coverallsapp/github-action@v2
         with:
           parallel: true
 
@@ -359,7 +391,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished
-      uses: AndreMiras/coveralls-python-action@develop
+      uses: coverallsapp/github-action@v2
       with:
         parallel-finished: true
 
@@ -516,6 +548,9 @@ jobs:
 
       - name: Restore pip cache permissions
         run: sudo chown -R $(whoami) ${{ steps.pip-cache-default.outputs.dir }}
+
+      - name: Prevent publishing wheels for unreleased Python versions
+        run: VER=$(echo '3.15' | tr -d .) && ls -al wheelhouse && sudo rm -f wheelhouse/*-cp${VER}*.whl && ls -al wheelhouse
 
   publish:
     name: Publish to PyPI

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -33,6 +33,7 @@ tox_env_map() {
         *"cp312"*) echo 'py312';;
         *"cp313"*) echo 'py313';;
         *"cp314"*) echo 'py314';;
+        *"cp315"*) echo 'py315';;
         *) echo 'py';;
     esac
 }
@@ -44,9 +45,15 @@ for PYBIN in /opt/python/*/bin; do
        [[ "${PYBIN}" == *"cp311/"* ]] || \
        [[ "${PYBIN}" == *"cp312/"* ]] || \
        [[ "${PYBIN}" == *"cp313/"* ]] || \
-       [[ "${PYBIN}" == *"cp314/"* ]] ; then
-        "${PYBIN}/pip" install -e /io/
-        "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+       [[ "${PYBIN}" == *"cp314/"* ]] || \
+       [[ "${PYBIN}" == *"cp315/"* ]] ; then
+        if [[ "${PYBIN}" == *"cp315/"* ]] ; then
+            "${PYBIN}/pip" install --pre -e /io/
+            "${PYBIN}/pip" wheel /io/ --pre -w wheelhouse/
+        else
+            "${PYBIN}/pip" install -e /io/
+            "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+        fi
         if [ `uname -m` == 'aarch64' ]; then
           cd /io/
           ${PYBIN}/pip install tox

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,13 +2,13 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/c-code
 [meta]
 template = "c-code"
-commit-id = "2c0272ea"
+commit-id = "fee4a500"
 
 [python]
 with-windows = true
 with-pypy = true
 with-sphinx-doctests = false
-with-future-python = false
+with-future-python = true
 with-macos = false
 with-docs = false
 with-free-threaded-python = false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Change log
 6.3 (unreleased)
 ----------------
 
+- Add preliminary support for Python 3.15 as of 3.15b1.
+
 - Add support for automatically building and publishing Windows/ARM64 wheels.
 
 - Add support for automatically building and publishing source distributions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ source = [
 [tool.setuptools.dynamic]
 readme = {file = ["README.rst", "CHANGES.rst"]}
 
+
 [tool.zest-releaser]
 create-wheel = false
 upload-pypi = false

--- a/src/Acquisition/tests.py
+++ b/src/Acquisition/tests.py
@@ -1727,250 +1727,157 @@ class TestGC(unittest.TestCase):
             self.assertEqual(counter[0], 1)
 
 
-def test_container_proxying():
-    """Make sure that recent python container-related slots are proxied.
+class TestContainerProxying(unittest.TestCase):
+    """Make sure that recent python container-related slots are proxied."""
 
-    >>> class Impl(Implicit):
-    ...     pass
+    def _make_container_class(self, base):
+        class C(base):
+            def __getitem__(self, key):
+                if isinstance(key, slice):
+                    return (key.start, key.stop, key.step)
+                if key == 4:
+                    raise IndexError
+                return key
 
-    >>> class C(Implicit):
-    ...     def __getitem__(self, key):
-    ...         if isinstance(key, slice):
-    ...             print('slicing...')
-    ...             return (key.start, key.stop, key.step)
-    ...         print('getitem', key)
-    ...         if key == 4:
-    ...             raise IndexError
-    ...         return key
-    ...     def __contains__(self, key):
-    ...         print('contains', repr(key))
-    ...         return key == 5
-    ...     def __iter__(self):
-    ...         print('iterating...')
-    ...         return iter((42,))
-    ...     def __getslice__(self, start, end):
-    ...         print('slicing...')
-    ...         return (start, end, None)
+            def __contains__(self, key):
+                return key == 5
 
-    The naked class behaves like this:
+            def __iter__(self):
+                return iter((42,))
 
-    >>> c = C()
-    >>> 3 in c
-    contains 3
-    False
-    >>> 5 in c
-    contains 5
-    True
-    >>> list(c)
-    iterating...
-    [42]
-    >>> c[5:10]
-    slicing...
-    (5, 10, None)
-    >>> c[5:] == (5, None, None)
-    slicing...
-    True
-    >>> c[:10] == (None, 10, None)
-    slicing...
-    True
-    >>> c[5:10:5] == (5, 10, 5)
-    slicing...
-    True
-    >>> c[::] == (None, None, None)
-    slicing...
-    True
+        return C
 
-    Let's put c in the context of i:
+    def _check_naked_container(self, C):
+        c = C()
+        self.assertNotIn(3, c)
+        self.assertIn(5, c)
+        self.assertEqual(list(c), [42])
+        self.assertEqual(c[5:10], (5, 10, None))
+        self.assertEqual(c[5:], (5, None, None))
+        self.assertEqual(c[:10], (None, 10, None))
+        self.assertEqual(c[5:10:5], (5, 10, 5))
+        self.assertEqual(c[::], (None, None, None))
 
-    >>> i = Impl()
-    >>> i.c = c
+    def _check_wrapped_container(self, ImplClass, C):
+        c = C()
+        i = ImplClass()
+        i.c = c
+        wrapped = i.c
 
-    Now check that __contains__ is properly used:
+        self.assertNotIn(3, wrapped)
+        self.assertIn(5, wrapped)
+        self.assertEqual(list(wrapped), [42])
+        self.assertEqual(wrapped[5:10], (5, 10, None))
+        self.assertEqual(wrapped[5:], (5, None, None))
+        self.assertEqual(wrapped[:10], (None, 10, None))
+        self.assertEqual(wrapped[5:10:5], (5, 10, 5))
+        self.assertEqual(wrapped[::], (None, None, None))
 
-    >>> 3 in i.c # c.__of__(i)
-    contains 3
-    False
-    >>> 5 in i.c
-    contains 5
-    True
-    >>> list(i.c)
-    iterating...
-    [42]
-    >>> i.c[5:10]
-    slicing...
-    (5, 10, None)
-    >>> i.c[5:] == (5, None, None)
-    slicing...
-    True
-    >>> i.c[:10] == (None, 10, None)
-    slicing...
-    True
-    >>> i.c[5:10:5] == (5, 10, 5)
-    slicing...
-    True
-    >>> i.c[::] == (None, None, None)
-    slicing...
-    True
+    def test_implicit_naked(self):
+        C = self._make_container_class(Implicit)
+        self._check_naked_container(C)
 
-    Let's let's test the same again with an explicit wrapper:
+    def test_implicit_wrapped(self):
+        class Impl(Implicit):
+            pass
 
-    >>> class Impl(Explicit):
-    ...     pass
+        C = self._make_container_class(Implicit)
+        self._check_wrapped_container(Impl, C)
 
-    >>> class C(Explicit):
-    ...     def __getitem__(self, key):
-    ...         if isinstance(key, slice):
-    ...             print('slicing...')
-    ...             return (key.start, key.stop, key.step)
-    ...         print('getitem', key)
-    ...         if key == 4:
-    ...             raise IndexError
-    ...         return key
-    ...     def __contains__(self, key):
-    ...         print('contains', repr(key))
-    ...         return key == 5
-    ...     def __iter__(self):
-    ...         print('iterating...')
-    ...         return iter((42,))
-    ...     def __getslice__(self, start, end):
-    ...         print('slicing...')
-    ...         return (start, end, None)
+    def test_explicit_naked(self):
+        C = self._make_container_class(Explicit)
+        self._check_naked_container(C)
 
-    The naked class behaves like this:
+    def test_explicit_wrapped(self):
+        class Impl(Explicit):
+            pass
 
-    >>> c = C()
-    >>> 3 in c
-    contains 3
-    False
-    >>> 5 in c
-    contains 5
-    True
-    >>> list(c)
-    iterating...
-    [42]
-    >>> c[5:10]
-    slicing...
-    (5, 10, None)
-    >>> c[5:] == (5, None, None)
-    slicing...
-    True
-    >>> c[:10] == (None, 10, None)
-    slicing...
-    True
-    >>> c[5:10:5] == (5, 10, 5)
-    slicing...
-    True
-    >>> c[::] == (None, None, None)
-    slicing...
-    True
+        C = self._make_container_class(Explicit)
+        self._check_wrapped_container(Impl, C)
 
-    Let's put c in the context of i:
+    def test_iter_fallback_to_getitem(self):
+        # The wrapper's __iter__ proxy falls back to using the object's
+        # __getitem__ if it has no __iter__.
+        # See https://bugs.launchpad.net/zope2/+bug/360761
+        class C(Implicit):
+            _list = [1, 2, 3]
 
-    >>> i = Impl()
-    >>> i.c = c
+            def __getitem__(self, i):
+                return self._list[i]
 
-    Now check that __contains__ is properly used:
+        c1 = C()
+        self.assertIsNotNone(iter(c1))
+        self.assertEqual(list(c1), [1, 2, 3])
 
-    >>> 3 in i.c # c.__of__(i)
-    contains 3
-    False
-    >>> 5 in i.c
-    contains 5
-    True
-    >>> list(i.c)
-    iterating...
-    [42]
-    >>> i.c[5:10]
-    slicing...
-    (5, 10, None)
-    >>> i.c[5:] == (5, None, None)
-    slicing...
-    True
-    >>> i.c[:10] == (None, 10, None)
-    slicing...
-    True
-    >>> i.c[5:10:5] == (5, 10, 5)
-    slicing...
-    True
-    >>> i.c[::] == (None, None, None)
-    slicing...
-    True
+        c2 = C().__of__(c1)
+        self.assertIsNotNone(iter(c2))
+        self.assertEqual(list(c2), [1, 2, 3])
 
-    Next let's check that the wrapper's __iter__ proxy falls back
-    to using the object's __getitem__ if it has no __iter__.  See
-    https://bugs.launchpad.net/zope2/+bug/360761 .
+    def test_iter_passes_wrapped_self(self):
+        # The __iter__ proxy should pass the wrapped object as self to
+        # the __iter__ of objects defining __iter__.
+        class Impl(Implicit):
+            pass
 
-    >>> class C(Implicit):
-    ...     l=[1,2,3]
-    ...     def __getitem__(self, i):
-    ...         return self.l[i]
+        class C(Implicit):
+            def __iter__(self):
+                for i in range(5):
+                    yield i, self.aq_parent.name
 
-    >>> c1 = C()
-    >>> type(iter(c1)) #doctest: +ELLIPSIS
-    <... '...iterator'>
-    >>> list(c1)
-    [1, 2, 3]
+        c = C()
+        i = Impl()
+        i.c = c
+        i.name = 'i'
+        self.assertEqual(
+            list(i.c),
+            [(0, 'i'), (1, 'i'), (2, 'i'), (3, 'i'), (4, 'i')],
+        )
 
-    >>> c2 = C().__of__(c1)
-    >>> type(iter(c2)) #doctest: +ELLIPSIS
-    <... '...iterator'>
-    >>> list(c2)
-    [1, 2, 3]
+    def test_getitem_passes_wrapped_self(self):
+        # The __iter__ proxy should pass the wrapped object as self to
+        # the __getitem__ of objects without an __iter__.
+        class Impl(Implicit):
+            pass
 
-    The __iter__proxy should also pass the wrapped object as self to
-    the __iter__ of objects defining __iter__:
+        class C(Implicit):
+            def __getitem__(self, i):
+                return self.aq_parent.lst[i]
 
-    >>> class C(Implicit):
-    ...     def __iter__(self):
-    ...         print('iterating...')
-    ...         for i in range(5):
-    ...             yield i, self.aq_parent.name
-    >>> c = C()
-    >>> i = Impl()
-    >>> i.c = c
-    >>> i.name = 'i'
-    >>> list(i.c)
-    iterating...
-    [(0, 'i'), (1, 'i'), (2, 'i'), (3, 'i'), (4, 'i')]
+        c = C()
+        i = Impl()
+        i.c = c
+        i.lst = range(5)
+        self.assertEqual(list(i.c), [0, 1, 2, 3, 4])
 
-    And it should pass the wrapped object as self to
-    the __getitem__ of objects without an __iter__:
+    def test_iter_error_no_iter(self):
+        # Objects with no __iter__ and no __getitem__ should raise TypeError.
+        class Impl(Implicit):
+            pass
 
-    >>> class C(Implicit):
-    ...     def __getitem__(self, i):
-    ...         return self.aq_parent.l[i]
-    >>> c = C()
-    >>> i = Impl()
-    >>> i.c = c
-    >>> i.l = range(5)
-    >>> list(i.c)
-    [0, 1, 2, 3, 4]
+        class C(Implicit):
+            pass
 
-    Finally let's make sure errors are still correctly raised after having
-    to use a modified version of `PyObject_GetIter` for iterator support:
+        c = C()
+        i = Impl()
+        i.c = c
+        with self.assertRaises(TypeError):
+            list(i.c)
 
-    >>> class C(Implicit):
-    ...     pass
-    >>> c = C()
-    >>> i = Impl()
-    >>> i.c = c
-    >>> list(i.c) #doctest: +ELLIPSIS
-    Traceback (most recent call last):
-      ...
-    TypeError: ...iter...
+    def test_iter_error_non_iterator_return(self):
+        # __iter__ returning a non-iterator should raise TypeError.
+        class Impl(Implicit):
+            pass
 
-    >>> class C(Implicit):
-    ...     def __iter__(self):
-    ...         return [42]
-    >>> c = C()
-    >>> i = Impl()
-    >>> i.c = c
-    >>> list(i.c) #doctest: +ELLIPSIS
-    Traceback (most recent call last):
-      ...
-    TypeError: iter() returned non-iterator...
+        class C(Implicit):
+            def __iter__(self):
+                return [42]
 
-    """
+        c = C()
+        i = Impl()
+        i.c = c
+        with self.assertRaises(TypeError) as cm:
+            list(i.c)
+        self.assertIn('iter', str(cm.exception).lower())
 
 
 class TestAqParentParentInteraction(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -10,10 +10,12 @@ envlist =
     py312,py312-pure
     py313,py313-pure
     py314,py314-pure
+    py315,py315-pure
     pypy3
     coverage
 
 [testenv]
+pip_pre = py315: true
 deps =
     setuptools >= 78.1.1,< 82
 setenv =


### PR DESCRIPTION
+ Rewrote a doctest to a unittest because the repr of the error changed for `__iter__` returning a non-iterator. But it was really hard to get a traceback for the error.